### PR TITLE
Add rest of (non binary) sensors

### DIFF
--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -702,7 +702,13 @@ def obj100a(
     batt = xobj[0]
     volt = 2.2 + (3.1 - 2.2) * (batt / 100)
     device.update_predefined_sensor(SensorLibrary.BATTERY__PERCENTAGE, batt)
-    return {"voltage": volt}
+    device.update_sensor(
+        key="voltage",
+        name="Voltage",
+        native_unit_of_measurement=Units.ELECTRIC_POTENTIAL_VOLT,
+        native_value=volt,
+    )
+    return {}
 
 
 def obj100d(

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -606,7 +606,13 @@ def obj1010(
     """Formaldehyde"""
     if len(xobj) == 2:
         (fmdh,) = FMDH_STRUCT.unpack(xobj)
-        return {"formaldehyde": fmdh / 100}
+        device.update_sensor(
+            key="formaldehyde",
+            name="Formaldehyde",
+            native_unit_of_measurement=Units.CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+            native_value=fmdh / 100,
+        )
+        return {}
     else:
         return {}
 

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -628,7 +628,13 @@ def obj1013(
     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
 ) -> dict[str, Any]:
     """Consumable (in percent)"""
-    return {"consumable": xobj[0]}
+    device.update_sensor(
+        key="consumable",
+        name="Consumable",
+        native_unit_of_measurement=Units.PERCENTAGE,
+        native_value=xobj[0],
+    )
+    return {}
 
 
 def obj1014(


### PR DESCRIPTION
I wanted to see how many more sensors types I could cover before the beta. Binary sensors aren't going to make it before beta, but we should be able to get most of the other sensors.

I have questions about a few, though.

* obj1014 - we label this as moisture, but according to iot.mi.com its flood detection. i'm guessing this is a binary sensor?
* obj1018 - "Light intensity" - is this lux?

Are there any other "easy" ones I could add to this PR? I think the rest are either definitely binary sensors or fairly complicated and i'm not sure if want to add them without more test data or an actual device to test with.