### PR TITLE
fix: track whether or not we have seen a packet with a payload (HA75833)

### DIFF
--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -966,9 +966,9 @@ class XiaomiBluetoothDeviceData(BluetoothData):
         # or encryption is not in use
         self.bindkey_verified = False
 
-        # This is set to true if we successfully detected a payload
-        # This includes the case where we parsed but skipped unsupported tags
-        self.seen_payload = False
+        # If this is True, then we have not seen an advertisement with a payload
+        # Until we see a payload, we can't tell if this device is encrypted or not
+        self.pending = True
 
     def supported(self, data: BluetoothServiceInfo) -> bool:
         if not super().supported(data):
@@ -1121,6 +1121,8 @@ class XiaomiBluetoothDeviceData(BluetoothData):
 
         # check that data contains object
         if frctrl_object_include != 0:
+            self.pending = False
+
             # check for encryption
             if frctrl_is_encrypted != 0:
                 sinfo += ", Encryption"
@@ -1186,8 +1188,6 @@ class XiaomiBluetoothDeviceData(BluetoothData):
                             data.hex(),
                         )
                 payload_start = next_start
-
-            self.seen_payload = True
 
         return self.unhandled
 

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -966,6 +966,10 @@ class XiaomiBluetoothDeviceData(BluetoothData):
         # or encryption is not in use
         self.bindkey_verified = False
 
+        # This is set to true if we successfully detected a payload
+        # This includes the case where we parsed but skipped unsupported tags
+        self.seen_payload = False
+
     def supported(self, data: BluetoothServiceInfo) -> bool:
         if not super().supported(data):
             return False
@@ -1182,6 +1186,8 @@ class XiaomiBluetoothDeviceData(BluetoothData):
                             data.hex(),
                         )
                 payload_start = next_start
+
+            self.seen_payload = True
 
         return self.unhandled
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -63,7 +63,6 @@ def test_blank_advertisemnts_then_encrypted():
 
     assert device.encryption_scheme == EncryptionScheme.NONE
     assert device.pending is True
-    assert not device.bindkey_verified
 
     # Second advertisement has encryption
     data_string = b"XX[\x05\x01H<\xd48\xc1\xa4\x9c\xf2U\xcf\xdd\x00\x00\x00/\xae/\xf2"
@@ -72,7 +71,6 @@ def test_blank_advertisemnts_then_encrypted():
 
     assert device.encryption_scheme == EncryptionScheme.MIBEACON_4_5
     assert device.pending is False
-    assert not device.bindkey_verified
 
 
 def test_blank_advertisemnts_then_unencrypted():
@@ -91,7 +89,6 @@ def test_blank_advertisemnts_then_unencrypted():
 
     assert device.encryption_scheme == EncryptionScheme.NONE
     assert device.pending is True
-    assert not device.bindkey_verified
 
     # Second advertisement has encryption
     data_string = b"q \x98\x00\x12\xf3Ok\x8d|\xc4\r\x04\x10\x02\xc4\x00"
@@ -100,7 +97,6 @@ def test_blank_advertisemnts_then_unencrypted():
 
     assert device.encryption_scheme == EncryptionScheme.NONE
     assert device.pending is False
-    assert not device.bindkey_verified
 
 
 def test_encryption_needs_v2():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -55,13 +55,14 @@ def test_blank_advertisemnts_then_encrypted():
     """Test that we can reject empty payloads."""
     device = XiaomiBluetoothDeviceData()
 
-    # First advertisement has a header but no payload, so we can't tell if it has encryption
+    # First advertisement has a header but no payload, so we can't tell
+    # if it has encryption
     data_string = b"0X[\x05\x02H<\xd48\xc1\xa4\x08"
     advertisement = bytes_to_service_info(data_string, address="A4:C1:38:D4:3C:48")
     assert device.supported(advertisement)
 
     assert device.encryption_scheme == EncryptionScheme.NONE
-    assert device.pending == True
+    assert device.pending is True
     assert not device.bindkey_verified
 
     # Second advertisement has encryption
@@ -70,7 +71,7 @@ def test_blank_advertisemnts_then_encrypted():
     device.update(advertisement)
 
     assert device.encryption_scheme == EncryptionScheme.MIBEACON_4_5
-    assert device.pending == False
+    assert device.pending is False
     assert not device.bindkey_verified
 
 
@@ -82,13 +83,14 @@ def test_blank_advertisemnts_then_unencrypted():
 
     device = XiaomiBluetoothDeviceData()
 
-    # First advertisement has a header but no payload, so we can't tell if it has encryption
+    # First advertisement has a header but no payload, so we can't tell
+    # if it has encryption
     data_string = b"1 \x98\x00\x12\xf3Ok\x8d|\xc4\r"
     advertisement = bytes_to_service_info(data_string, address="C4:7C:8D:6B:4F:F3")
     assert device.supported(advertisement)
 
     assert device.encryption_scheme == EncryptionScheme.NONE
-    assert device.pending == True
+    assert device.pending is True
     assert not device.bindkey_verified
 
     # Second advertisement has encryption
@@ -97,7 +99,7 @@ def test_blank_advertisemnts_then_unencrypted():
     device.update(advertisement)
 
     assert device.encryption_scheme == EncryptionScheme.NONE
-    assert device.pending == False
+    assert device.pending is False
     assert not device.bindkey_verified
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -61,7 +61,7 @@ def test_blank_advertisemnts_then_encrypted():
     assert device.supported(advertisement)
 
     assert device.encryption_scheme == EncryptionScheme.NONE
-    assert device.seen_payload == False
+    assert device.pending == True
     assert not device.bindkey_verified
 
     # Second advertisement has encryption
@@ -70,7 +70,7 @@ def test_blank_advertisemnts_then_encrypted():
     device.update(advertisement)
 
     assert device.encryption_scheme == EncryptionScheme.MIBEACON_4_5
-    assert device.seen_payload == False
+    assert device.pending == False
     assert not device.bindkey_verified
 
 
@@ -88,7 +88,7 @@ def test_blank_advertisemnts_then_unencrypted():
     assert device.supported(advertisement)
 
     assert device.encryption_scheme == EncryptionScheme.NONE
-    assert device.seen_payload == False
+    assert device.pending == True
     assert not device.bindkey_verified
 
     # Second advertisement has encryption
@@ -97,7 +97,7 @@ def test_blank_advertisemnts_then_unencrypted():
     device.update(advertisement)
 
     assert device.encryption_scheme == EncryptionScheme.NONE
-    assert device.seen_payload == True
+    assert device.pending == False
     assert not device.bindkey_verified
 
 


### PR DESCRIPTION
Basically just expose `frctrl_object_include` as public API gives us 3 cases:

* A valid header was received but it contained no payload. We can't tell if this device uses encryption or not.
* A valid header was received and it contains an unencrypted payload. We can finish the config flow without any further prompts.
* A valid header was received and it contains an encrypted payload. We can prompt for the bindkey in the config flow.

We can't currently handle case (1) and we think we are seeomg that [here](https://github.com/home-assistant/core/issues/75833).

# Notes for HA side

This is to be used in HA with something broadly like this pseudcode:

```python
from homeassistant.components import bluetooth

# This was creating in the config flow and fed an advertisement
# device.pending is currently true, which means it needs to see more advertisements before we can proceed
device = XiaomiBluetoothDeviceData()

done = asyncio.Future()

@callback
def _async_discovered_device(service_info: bluetooth.BluetoothServiceInfo, change: bluetooth.BluetoothChange) -> None:
    device.update(service_info)
    if not device.pending:
        done.set()

unload = bluetooth.async_register_callback(
    hass, _async_discovered_device, {"address": device.address)}
)

async with async_timeout(5):
    await done

unload()

# Now can test if device.encryption_scheme == EncryptionScheme.MIBEACON_4_5 etc
```

It would be nicer if we could make that more like:

```python
async with async_timeout(5):
    async with bluetooth.async_discover({"address": "XX:XX:XX..."}) as iter:
        async for service_info, change in iter:
            device.update(service_info)
            if not device.pending:
                # Looks like we got a payload, so we can safely test for encryption
                break
```

`__aenter__` would register a callback, and `__aexit__` would unload it.

Though I think the wrapper would need to queue the adverisements as we can't block the callback. Is that OK? What would be a sensible max queue size?
