### PR TITLE
feat: support polling MiFlora battery

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,14 @@ optional = true
 python-versions = "*"
 
 [[package]]
+name = "async-timeout"
+version = "4.0.2"
+description = "Timeout context manager for asyncio programs"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "atomicwrites"
 version = "1.4.1"
 description = "Atomic file writes."
@@ -16,17 +24,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "21.4.0"
+version = "22.1.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "babel"
@@ -63,7 +71,7 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "bleak"
-version = "0.14.3"
+version = "0.15.1"
 description = "Bluetooth Low Energy platform Agnostic Klient"
 category = "main"
 optional = false
@@ -75,6 +83,22 @@ dbus-next = {version = "*", markers = "platform_system == \"Linux\""}
 pyobjc-core = {version = "*", markers = "platform_system == \"Darwin\""}
 pyobjc-framework-CoreBluetooth = {version = "*", markers = "platform_system == \"Darwin\""}
 pyobjc-framework-libdispatch = {version = "*", markers = "platform_system == \"Darwin\""}
+typing-extensions = ">=4.2.0"
+
+[[package]]
+name = "bleak-retry-connector"
+version = "1.4.0"
+description = "A connector for Bleak Clients that handles transient connection failures"
+category = "main"
+optional = false
+python-versions = ">=3.9,<4.0"
+
+[package.dependencies]
+async-timeout = ">=4.0.1"
+bleak = ">=0.14.3"
+
+[package.extras]
+docs = ["sphinx-rtd-theme (>=1.0,<2.0)", "myst-parser (>=0.18,<0.19)", "Sphinx (>=5.0,<6.0)"]
 
 [[package]]
 name = "bleak-winrt"
@@ -551,7 +575,7 @@ python-versions = "*"
 
 [[package]]
 name = "pyupgrade"
-version = "2.37.2"
+version = "2.37.3"
 description = "A tool to automatically upgrade syntax for newer versions."
 category = "dev"
 optional = false
@@ -607,7 +631,7 @@ python-versions = "*"
 
 [[package]]
 name = "sphinx"
-version = "5.0.2"
+version = "5.1.1"
 description = "Python documentation generator"
 category = "main"
 optional = true
@@ -617,7 +641,7 @@ python-versions = ">=3.6"
 alabaster = ">=0.7,<0.8"
 babel = ">=1.3"
 colorama = {version = ">=0.3.5", markers = "sys_platform == \"win32\""}
-docutils = ">=0.14,<0.19"
+docutils = ">=0.14,<0.20"
 imagesize = "*"
 importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
 Jinja2 = ">=2.3"
@@ -634,7 +658,7 @@ sphinxcontrib-serializinghtml = ">=1.1.5"
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
-lint = ["flake8 (>=3.5.0)", "isort", "mypy (>=0.950)", "docutils-stubs", "types-typed-ast", "types-requests"]
+lint = ["flake8 (>=3.5.0)", "flake8-comprehensions", "flake8-bugbear", "isort", "mypy (>=0.971)", "sphinx-lint", "docutils-stubs", "types-typed-ast", "types-requests"]
 test = ["pytest (>=4.6)", "html5lib", "cython", "typed-ast"]
 
 [[package]]
@@ -749,7 +773,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.26.10"
+version = "1.26.11"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = true
@@ -778,18 +802,20 @@ docs = ["myst-parser", "Sphinx", "sphinx-rtd-theme"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "ce33f329b05de96d8c7b5fb320bc376a5fbb743a044575b977fe2d995397a78f"
+content-hash = "410ae02b6c954802dddfa281dba63fc4bc1e10ba64a9cd4f49ca5932181d5139"
 
 [metadata.files]
 alabaster = []
-atomicwrites = []
-attrs = [
-    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
-    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+async-timeout = [
+    {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
+    {file = "async_timeout-4.0.2-py3-none-any.whl", hash = "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"},
 ]
+atomicwrites = []
+attrs = []
 babel = []
 black = []
 bleak = []
+bleak-retry-connector = []
 bleak-winrt = [
     {file = "bleak-winrt-1.1.1.tar.gz", hash = "sha256:3e7765f98d71b5229d95bd3b197931994dead40f3144e7186de7b8f664e26df0"},
     {file = "bleak_winrt-1.1.1-cp310-cp310-win32.whl", hash = "sha256:f1ab6641cfdadce69126b459c5d30f1a934384bc0c37632393163eea3c94d7a8"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ myst-parser = {version = "^0.18", optional = true}
 home-assistant-bluetooth = ">=1.3.0"
 sensor-state-data = ">=2.0.2"
 bluetooth-sensor-state-data = ">=1.5.0"
-pycryptodomex = "^3.15.0"
+pycryptodomex = ">=3.15.0"
+bleak-retry-connector = ">=1.4.0"
 
 [tool.poetry.extras]
 docs = [

--- a/src/xiaomi_ble/const.py
+++ b/src/xiaomi_ble/const.py
@@ -1,0 +1,5 @@
+TIMEOUT_1DAY = 86400
+
+# This characteristic contains the current battery level for a HHCCJCY01
+# as well as the firmware version
+CHARACTERISTIC_BATTERY = "00001a02-0000-1000-8000-00805f9b34fb"

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -16,11 +16,11 @@ from typing import Any
 
 from bleak import BleakClient
 from bleak.backends.device import BLEDevice
+from bleak_retry_connector import establish_connection
 from bluetooth_sensor_state_data import BluetoothData
 from Cryptodome.Cipher import AES
 from home_assistant_bluetooth import BluetoothServiceInfo
 from sensor_state_data import DeviceClass, SensorLibrary, SensorUpdate, Units
-from bleak_retry_connector import establish_connection
 
 from xiaomi_ble.const import CHARACTERISTIC_BATTERY, TIMEOUT_1DAY
 

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -5,7 +5,6 @@ MIT License applies.
 """
 from __future__ import annotations
 
-import asyncio
 import datetime
 import logging
 import math

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -5,6 +5,7 @@ MIT License applies.
 """
 from __future__ import annotations
 
+import asyncio
 import datetime
 import logging
 import math
@@ -13,10 +14,15 @@ import sys
 from enum import Enum
 from typing import Any
 
+from bleak import BleakClient
+from bleak.backends.device import BLEDevice
 from bluetooth_sensor_state_data import BluetoothData
 from Cryptodome.Cipher import AES
 from home_assistant_bluetooth import BluetoothServiceInfo
-from sensor_state_data import DeviceClass, SensorLibrary, Units
+from sensor_state_data import DeviceClass, SensorLibrary, SensorUpdate, Units
+from bleak_retry_connector import establish_connection
+
+from xiaomi_ble.const import CHARACTERISTIC_BATTERY, TIMEOUT_1DAY
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1083,6 +1089,9 @@ class XiaomiBluetoothDeviceData(BluetoothData):
 
         self.set_device_type(device_type)
 
+        self.device_id = device_id
+        self.device_type = device_type
+
         packet_id = data[4]
 
         sinfo = "MiVer: " + str(frctrl_version)
@@ -1285,3 +1294,37 @@ class XiaomiBluetoothDeviceData(BluetoothData):
             return None
         self.bindkey_verified = True
         return decrypted_payload
+
+    def poll_needed(
+        self, service_info: BluetoothServiceInfo, last_poll: float | None
+    ) -> bool:
+        """
+        This is called every time we get a service_info for a device. It means the
+        device is working and online. If 24 hours has passed, it may be a good
+        time to poll the device.
+        """
+        if self.device_id != 0x0098:
+            return False
+
+        return not last_poll or last_poll > TIMEOUT_1DAY
+
+    async def async_poll(self, ble_device: BLEDevice) -> SensorUpdate:
+        """
+        Poll the device to retrieve any values we can't get from passive listening.
+        """
+        if self.device_id == 0x0098:
+            client = await establish_connection(
+                BleakClient, ble_device, ble_device.address
+            )
+            try:
+                battery_char = client.services.get_characteristic(
+                    CHARACTERISTIC_BATTERY
+                )
+                payload = await client.read_gatt_char(battery_char)
+            finally:
+                await client.disconnect()
+
+            self.set_device_sw_version(payload[2:].decode("utf-8"))
+            self.update_predefined_sensor(SensorLibrary.BATTERY__PERCENTAGE, payload[0])
+
+        return self._finish_update()


### PR DESCRIPTION
See #10. This adds 2 new methods that will be called be a new API in Home Assistant - `ActiveDataProcessor` - which will check the battery on a MiFlora once a day, or the first time we see a MiFlor after 24 hours.