### PR TITLE
fix: bump sensor-state-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Sphinx = {version = "^5.0", optional = true}
 sphinx-rtd-theme = {version = "^1.0", optional = true}
 myst-parser = {version = "^0.18", optional = true}
 home-assistant-bluetooth = ">=1.3.0"
-sensor-state-data = ">=2.12.0"
+sensor-state-data = ">=2.12.1"
 bluetooth-sensor-state-data = ">=1.5.0"
 pycryptodomex = ">=3.15.0"
 bleak-retry-connector = ">=1.15.0"


### PR DESCRIPTION
pyproject.toml file wasn't updated with latest sensor-state-data version

fix: bump sensor-state-data to 2.12.1