### PR TITLE
feat: add new xiaomi sensors

### DIFF
--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -69,6 +69,10 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         name="Switch (triple button)",
         model="K9B-3BTN",
     ),
+    0x1C10: DeviceEntry(
+        name="Switch (single button)",
+        model="K9BB-1BTN",
+    ),
     0x1889: DeviceEntry(
         name="Door/Window Sensor",
         model="MS1BB(MI)",
@@ -92,6 +96,10 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
     0x055B: DeviceEntry(
         name="Temperature/Humidity Sensor",
         model="LYWSD03MMC",
+    ),
+    0x2832: DeviceEntry(
+        name="Temperature/Humidity Sensor",
+        model="MJWSD05MMC",
     ),
     0x098B: DeviceEntry(
         name="Door/Window Sensor",
@@ -152,6 +160,10 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
     0x1949: DeviceEntry(
         name="Button",
         model="XMWXKG01YL",
+    ),
+    0x2387: DeviceEntry(
+        name="Button",
+        model="XMWXKG01LM",
     ),
     0x098C: DeviceEntry(
         name="Push Pull Lock",

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -721,8 +721,8 @@ def obj2000(
     return {}
 
 
-# The following data objects are device specific. For now only
-#  added for LYWSD02MMC, MJWSD05MMC, XMWSDJ04MMC, XMWXKG01YL, LINPTECH MS1BB(MI), HS1BB(MI), K9BB
+# The following data objects are device specific. For now only added for 
+# LYWSD02MMC, MJWSD05MMC, XMWSDJ04MMC, XMWXKG01YL, LINPTECH MS1BB(MI), HS1BB(MI), K9BB
 # https://miot-spec.org/miot-spec-v2/instances?status=all
 def obj4803(
     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
@@ -992,9 +992,11 @@ def obj4e0e(
     return result
 
 
-def obj4e1c(xobj):
+def obj4e1c(
+    xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
+) -> dict[str, Any]:
     """Device reset"""
-    return {"device reset": xobj[0]}
+    return {"device reset": True}
 
 
 # Dataobject dictionary
@@ -1041,7 +1043,7 @@ xiaomi_dataobject_dict = {
     0x4C03: obj4c03,
     0x4C08: obj4c08,
     0x4C14: obj4c14,
-    0x4e1c: obj4e1c,
+    0x4E1c: obj4e1c,
     0x4E0C: obj4e0c,
     0x4E0D: obj4e0d,
     0x4E0E: obj4e0e,

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -721,7 +721,7 @@ def obj2000(
     return {}
 
 
-# The following data objects are device specific. For now only added for 
+# The following data objects are device specific. For now only added for
 # LYWSD02MMC, MJWSD05MMC, XMWSDJ04MMC, XMWXKG01YL, LINPTECH MS1BB(MI), HS1BB(MI), K9BB
 # https://miot-spec.org/miot-spec-v2/instances?status=all
 def obj4803(
@@ -1043,7 +1043,7 @@ xiaomi_dataobject_dict = {
     0x4C03: obj4c03,
     0x4C08: obj4c08,
     0x4C14: obj4c14,
-    0x4E1c: obj4e1c,
+    0x4E1C: obj4e1c,
     0x4E0C: obj4e0c,
     0x4E0D: obj4e0d,
     0x4E0E: obj4e0e,

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -722,7 +722,7 @@ def obj2000(
 
 
 # The following data objects are device specific. For now only
-#  added for LYWSD02MMC, XMWSDJ04MMC, XMWXKG01YL, LINPTECH MS1BB(MI), HS1BB(MI)
+#  added for LYWSD02MMC, MJWSD05MMC, XMWSDJ04MMC, XMWXKG01YL, LINPTECH MS1BB(MI), HS1BB(MI), K9BB
 # https://miot-spec.org/miot-spec-v2/instances?status=all
 def obj4803(
     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
@@ -887,15 +887,44 @@ def obj4e0c(
     result: dict[str, Any] = {}
 
     click = xobj[0]
-
-    if click == 1:
-        result["two_btn_switch_left"] = "toggle"
-    elif click == 2:
-        result["two_btn_switch_right"] = "toggle"
-    elif click == 3:
-        result["two_btn_switch_left"] = "toggle"
-        result["two_btn_switch_right"] = "toggle"
-
+    if device_type == "XMWXKG01YL":
+        if click == 1:
+            result = {
+                "two btn switch left": "toggle",
+                "button switch": "single press",
+            }
+        elif click == 2:
+            result = {
+                "two btn switch right": "toggle",
+                "button switch": "single press",
+            }
+        elif click == 3:
+            result = {
+                "two btn switch left": "toggle",
+                "two btn switch right": "toggle",
+                "button switch": "single press",
+            }
+    elif device_type == "K9BB-1BTN":
+        if click == 1:
+            result = {
+                "one btn switch": "toggle",
+                "button switch": "single press",
+            }
+        elif click == 8:
+            result = {
+                "one btn switch": "toggle",
+                "button switch": "long press",
+            }
+        elif click == 15:
+            result = {
+                "one btn switch": "toggle",
+                "button switch": "double press",
+            }
+    elif device_type == "XMWXKG01LM":
+        result = {
+            "one btn switch": "toggle",
+            "button switch": "single press",
+        }
     return result
 
 
@@ -903,48 +932,69 @@ def obj4e0d(
     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
 ) -> dict[str, Any]:
     """Double Click"""
+    result: dict[str, Any] = {}
+
     click = xobj[0]
-    btn_switch_press_type: str | None = "double press"
-    two_btn_switch_left = None
-    two_btn_switch_right = None
-    if click == 1:
-        two_btn_switch_left = "toggle"
-    elif click == 2:
-        two_btn_switch_right = "toggle"
-    elif click == 3:
-        two_btn_switch_left = "toggle"
-        two_btn_switch_right = "toggle"
-    else:
-        btn_switch_press_type = None
-    return {
-        "two btn switch left": two_btn_switch_left,
-        "two btn switch right": two_btn_switch_right,
-        "button switch": btn_switch_press_type,
-    }
+    if device_type == "XMWXKG01YL":
+        if click == 1:
+            result = {
+                "two btn switch left": "toggle",
+                "button switch": "double press",
+            }
+        elif click == 2:
+            result = {
+                "two btn switch right": "toggle",
+                "button switch": "double press",
+            }
+        elif click == 3:
+            result = {
+                "two btn switch left": "toggle",
+                "two btn switch right": "toggle",
+                "button switch": "double press",
+            }
+    elif device_type == "XMWXKG01LM":
+        result = {
+            "one btn switch": "toggle",
+            "button switch": "double press",
+        }
+    return result
 
 
 def obj4e0e(
     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
 ) -> dict[str, Any]:
     """Long Press"""
+    result: dict[str, Any] = {}
+
     click = xobj[0]
-    btn_switch_press_type: str | None = "long press"
-    two_btn_switch_left = None
-    two_btn_switch_right = None
-    if click == 1:
-        two_btn_switch_left = "toggle"
-    elif click == 2:
-        two_btn_switch_right = "toggle"
-    elif click == 3:
-        two_btn_switch_left = "toggle"
-        two_btn_switch_right = "toggle"
-    else:
-        btn_switch_press_type = None
-    return {
-        "two btn switch left": two_btn_switch_left,
-        "two btn switch right": two_btn_switch_right,
-        "button switch": btn_switch_press_type,
-    }
+    if device_type == "XMWXKG01YL":
+        if click == 1:
+            result = {
+                "two btn switch left": "toggle",
+                "button switch": "long press",
+            }
+        elif click == 2:
+            result = {
+                "two btn switch right": "toggle",
+                "button switch": "long press",
+            }
+        elif click == 3:
+            result = {
+                "two btn switch left": "toggle",
+                "two btn switch right": "toggle",
+                "button switch": "long press",
+            }
+    elif device_type == "XMWXKG01LM":
+        result = {
+            "one btn switch": "toggle",
+            "button switch": "long press",
+        }
+    return result
+
+
+def obj4e1c(xobj):
+    """Device reset"""
+    return {"device reset": xobj[0]}
 
 
 # Dataobject dictionary
@@ -991,6 +1041,7 @@ xiaomi_dataobject_dict = {
     0x4C03: obj4c03,
     0x4C08: obj4c08,
     0x4C14: obj4c14,
+    0x4e1c: obj4e1c,
     0x4E0C: obj4e0c,
     0x4E0D: obj4e0d,
     0x4E0E: obj4e0e,


### PR DESCRIPTION
- Add support for Xiaomi Mijia Smart Temperature and Humidity Monitor 3 (MJWSD05MMC)
- Add support for Xiaomi Wireless Switch (Bluetooth) (XMWXKG01LM)
- Add support for Linptech K9BB wall switch (battery powered, 1 button version)

Note. The last two won't really work yet, as the button switch sensor isn't implemented yet. But with this PR, we have the info ready when we are going to add the button switches. 