### PR TITLE
fix: use only kg for mass

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1375,13 +1375,13 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "sensor-state-data"
-version = "2.17.0"
+version = "2.17.1"
 description = "Models for storing and converting Sensor Data state"
 optional = false
 python-versions = ">=3.9,<4.0"
 files = [
-    {file = "sensor_state_data-2.17.0-py3-none-any.whl", hash = "sha256:0580a7f93a6af5fa7a3413a56638f81db34c813599aff3c6c8b21dc2d8a33af0"},
-    {file = "sensor_state_data-2.17.0.tar.gz", hash = "sha256:dc90955dd7975f7f0adee108b637764145dcc6d28212c124bc4ec89140dcce49"},
+    {file = "sensor_state_data-2.17.1-py3-none-any.whl", hash = "sha256:d5c023cefa43671624508ac1594167c8391860309a526e4052e637259ba6daa5"},
+    {file = "sensor_state_data-2.17.1.tar.gz", hash = "sha256:ae430fd6f29dd9f5681196ae9c1058e4fdd17e6e0c3154afc34e210f7a651fe5"},
 ]
 
 [package.extras]
@@ -1708,4 +1708,4 @@ docs = ["Sphinx", "myst-parser", "sphinx-rtd-theme"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "56ff3d1a13aa9224e3516ae96b557bfd14023ad6e2d9ec8336435a81714655b0"
+content-hash = "9dd73fe8fb1a7c0271f07a33bd1e4fb1c6daa39c235284acea5cc50b8c48f5c5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Sphinx = {version = "^5.0", optional = true}
 sphinx-rtd-theme = {version = "^1.0", optional = true}
 myst-parser = {version = "^0.18", optional = true}
 home-assistant-bluetooth = ">=1.9.2"
-sensor-state-data = ">=2.17.0"
+sensor-state-data = ">=2.17.1"
 bluetooth-sensor-state-data = ">=1.6.0"
 pycryptodomex = ">=3.16.0"
 bleak-retry-connector = ">=2.13.0"

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1535,31 +1535,25 @@ class XiaomiBluetoothDeviceData(BluetoothData):
 
         mass_in_pounds = bool(int(control_flags[7]))
         mass_in_catty = bool(int(control_flags[9]))
-        mass_stabilized = bool(int(control_flags[10]))
         mass_in_kilograms = not mass_in_catty and not mass_in_pounds
+        mass_stabilized = bool(int(control_flags[10]))
         impedance_stabilized = bool(int(control_flags[14]))
 
         if mass_in_kilograms:
+            # sensor advertises kg * 200
             mass /= 200
+        elif mass_in_pounds:
+            # sensor advertises lbs * 100, conversion to kg (1 lbs = 0.45359237 kg)
+            mass *= 0.0045359237
         else:
-            mass /= 100
+            # sensor advertises catty * 100, conversion to kg (1 catty = 0.5 kg)
+            mass *= 0.005
 
-        stabilized_mass_type = (
-            SensorLibrary.MASS_STABILIZED__MASS_KILOGRAMS
-            if mass_in_kilograms
-            else SensorLibrary.MASS_STABILIZED__MASS_POUNDS
+        self.update_predefined_sensor(
+            SensorLibrary.MASS_NON_STABILIZED__MASS_KILOGRAMS, mass
         )
-
-        non_stabilized_mass_type = (
-            SensorLibrary.MASS_NON_STABILIZED__MASS_KILOGRAMS
-            if mass_in_kilograms
-            else SensorLibrary.MASS_NON_STABILIZED__MASS_POUNDS
-        )
-
-        self.update_predefined_sensor(non_stabilized_mass_type, mass)
-
         if mass_stabilized:
-            self.update_predefined_sensor(stabilized_mass_type, mass)
+            self.update_predefined_sensor(SensorLibrary.MASS__MASS_KILOGRAMS, mass)
             if impedance_stabilized:
                 self.update_predefined_sensor(SensorLibrary.IMPEDANCE__OHM, impedance)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -41,7 +41,7 @@ KEY_HUMIDITY = DeviceKey(key="humidity", device_id=None)
 KEY_ILLUMINANCE = DeviceKey(key="illuminance", device_id=None)
 KEY_IMPEDANCE = DeviceKey(key="impedance", device_id=None)
 KEY_MASS_NON_STABILIZED = DeviceKey(key="mass_non_stabilized", device_id=None)
-KEY_MASS_STABILIZED = DeviceKey(key="mass_stabilized", device_id=None)
+KEY_MASS = DeviceKey(key="mass", device_id=None)
 KEY_MOISTURE = DeviceKey(key="moisture", device_id=None)
 KEY_SIGNAL_STRENGTH = DeviceKey(key="signal_strength", device_id=None)
 KEY_SMOKE = DeviceKey(key="smoke", device_id=None)
@@ -1084,9 +1084,9 @@ def test_Xiaomi_Scale2():
                 device_class=DeviceClass.MASS_NON_STABILIZED,
                 native_unit_of_measurement=Units.MASS_KILOGRAMS,
             ),
-            KEY_MASS_STABILIZED: SensorDescription(
-                device_key=KEY_MASS_STABILIZED,
-                device_class=DeviceClass.MASS_STABILIZED,
+            KEY_MASS: SensorDescription(
+                device_key=KEY_MASS,
+                device_class=DeviceClass.MASS,
                 native_unit_of_measurement=Units.MASS_KILOGRAMS,
             ),
             KEY_IMPEDANCE: SensorDescription(
@@ -1106,9 +1106,9 @@ def test_Xiaomi_Scale2():
                 device_key=KEY_MASS_NON_STABILIZED,
                 native_value=58.85,
             ),
-            KEY_MASS_STABILIZED: SensorValue(
-                name="Mass Stabilized",
-                device_key=KEY_MASS_STABILIZED,
+            KEY_MASS: SensorValue(
+                name="Mass",
+                device_key=KEY_MASS,
                 native_value=58.85,
             ),
             KEY_IMPEDANCE: SensorValue(


### PR DESCRIPTION
fix: use only kg for mass

As requested by @emontnemery in https://github.com/home-assistant/core/pull/96807, I'm going to forward MiScale data only in kg, and I will use the Mass sensor for stabilized mass/weight. So I only need the non-stabilized mass sensor type.