### PR TITLE
fix: rename rubiks_cube to cube

### DIFF
--- a/src/xiaomi_ble/events.py
+++ b/src/xiaomi_ble/events.py
@@ -16,5 +16,5 @@ class EventDeviceKeys(StrEnum):
     # Motion
     MOTION = "motion"
 
-    # Rubiks Cube
-    RUBIKS_CUBE = "rubiks_cube"
+    # Cube
+    CUBE = "cube"

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -582,7 +582,7 @@ def obj1001(
     elif device_type == "XMMF01JQD":
         # cube_rotation: rotate_left or rotate_right
         device.fire_event(
-            key=EventDeviceKeys.RUBIKS_CUBE,
+            key=EventDeviceKeys.CUBE,
             event_type=cube_rotation,
             event_properties=None,
         )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -42,7 +42,7 @@ KEY_COUNTER = DeviceKey(key="counter", device_id=None)
 KEY_EVENT_BUTTON = DeviceKey(key="button", device_id=None)
 KEY_EVENT_DIMMER = DeviceKey(key="dimmer", device_id=None)
 KEY_EVENT_MOTION = DeviceKey(key="motion", device_id=None)
-KEY_EVENT_RUBIKS_CUBE = DeviceKey(key="rubiks_cube", device_id=None)
+KEY_EVENT_CUBE = DeviceKey(key="cube", device_id=None)
 KEY_HUMIDITY = DeviceKey(key="humidity", device_id=None)
 KEY_ILLUMINANCE = DeviceKey(key="illuminance", device_id=None)
 KEY_IMPEDANCE = DeviceKey(key="impedance", device_id=None)
@@ -741,9 +741,9 @@ def test_Xiaomi_XMMF01JQD():
             ),
         },
         events={
-            KEY_EVENT_RUBIKS_CUBE: Event(
-                device_key=KEY_EVENT_RUBIKS_CUBE,
-                name="Rubiks Cube",
+            KEY_EVENT_CUBE: Event(
+                device_key=KEY_EVENT_CUBE,
+                name="Cube",
                 event_type="rotate_left",
                 event_properties=None,
             ),


### PR DESCRIPTION
fix: rename rubiks_cube to cube

HA is splitting up events based on the underscore, which should not be done for the rubiks cube