### PR TITLE
feat: add support for PTX_YK1_QMIMB / 090615.remote.btsw1

### DIFF
--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -181,6 +181,10 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         name="Button",
         model="XMWXKG01LM",
     ),
+    0x38BB: DeviceEntry(
+        name="Button",
+        model="PTX_YK1_QMIMB",
+    ),
     0x098C: DeviceEntry(
         name="Door Lock",
         model="XMZNMST02YD",

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1071,6 +1071,42 @@ def obj4a08(
     return {}
 
 
+def obj4a0c(
+    xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
+) -> dict[str, Any]:
+    if device_type == "PTX_YK1_QMIMB":
+        device.fire_event(
+            key=EventDeviceKeys.BUTTON,
+            event_type="press",
+            event_properties=None,
+        )
+    return {}
+
+
+def obj4a0d(
+    xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
+) -> dict[str, Any]:
+    if device_type == "PTX_YK1_QMIMB":
+        device.fire_event(
+            key=EventDeviceKeys.BUTTON,
+            event_type="double_press",
+            event_properties=None,
+        )
+    return {}
+
+
+def obj4a0e(
+    xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
+) -> dict[str, Any]:
+    if device_type == "PTX_YK1_QMIMB":
+        device.fire_event(
+            key=EventDeviceKeys.BUTTON,
+            event_type="long_press",
+            event_properties=None,
+        )
+    return {}
+
+
 def obj4a0f(
     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
 ) -> dict[str, Any]:
@@ -1376,6 +1412,9 @@ xiaomi_dataobject_dict = {
     0x4818: obj4818,
     0x4A01: obj4a01,
     0x4A08: obj4a08,
+    0x4A0C: obj4a0c,
+    0x4A0D: obj4a0d,
+    0x4A0E: obj4a0e,
     0x4A0F: obj4a0f,
     0x4A12: obj4a12,
     0x4A13: obj4a13,
@@ -1713,16 +1752,15 @@ class XiaomiBluetoothDeviceData(BluetoothData):
                     break
                 this_start = payload_start + 3
                 dobject = payload[this_start:next_start]
-                if obj_length != 0:
-                    resfunc = xiaomi_dataobject_dict.get(obj_typecode, None)
-                    if resfunc:
-                        self.unhandled.update(resfunc(dobject, self, device_type))
-                    else:
-                        _LOGGER.info(
-                            "%s, UNKNOWN dataobject in payload! Adv: %s",
-                            sinfo,
-                            data.hex(),
-                        )
+                resfunc = xiaomi_dataobject_dict.get(obj_typecode, None)
+                if resfunc:
+                    self.unhandled.update(resfunc(dobject, self, device_type))
+                else:
+                    _LOGGER.info(
+                        "%s, UNKNOWN dataobject in payload! Adv: %s",
+                        sinfo,
+                        data.hex(),
+                    )
                 payload_start = next_start
 
         return True

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2505,6 +2505,122 @@ def test_Xiaomi_XMWXKG01YL():
     )
 
 
+def test_Xiaomi_PTX_YK1_QMIMB():
+    """Test Xiaomi parser for PTX_YK1_QMIMB / 090615.remote.btsw1."""
+    # press
+    data_string = bytes.fromhex("5859bb380fb26a1a38c1a46756c02a0000e75ef84c")
+    advertisement = bytes_to_service_info(data_string, address="A4:C1:38:1A:6A:B2")
+    bindkey = "6fb3f0c214eef4f7ad78467d9aa5fc16"
+
+    device = XiaomiBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
+    assert device.supported(advertisement)
+    assert device.bindkey_verified
+    assert device.update(advertisement) == SensorUpdate(
+        title="Button 6AB2 (PTX_YK1_QMIMB)",
+        devices={
+            None: SensorDeviceInfo(
+                name="Button 6AB2",
+                manufacturer="Xiaomi",
+                model="PTX_YK1_QMIMB",
+                hw_version=None,
+                sw_version="Xiaomi (MiBeacon V5 encrypted)",
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement="dBm",
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
+            ),
+        },
+        events={
+            DeviceKey(key="button", device_id=None): Event(
+                device_key=DeviceKey(key="button", device_id=None),
+                name="Button",
+                event_type="press",
+                event_properties=None,
+            ),
+        },
+    )
+
+    # double press
+    data_string = bytes.fromhex("5859bb3810b26a1a38c1a433ea1b2a0000bad2e4b6")
+    advertisement = bytes_to_service_info(data_string, address="A4:C1:38:1A:6A:B2")
+    assert device.update(advertisement) == SensorUpdate(
+        title="Button 6AB2 (PTX_YK1_QMIMB)",
+        devices={
+            None: SensorDeviceInfo(
+                name="Button 6AB2",
+                manufacturer="Xiaomi",
+                model="PTX_YK1_QMIMB",
+                hw_version=None,
+                sw_version="Xiaomi (MiBeacon V5 encrypted)",
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement="dBm",
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
+            ),
+        },
+        events={
+            DeviceKey(key="button", device_id=None): Event(
+                device_key=DeviceKey(key="button", device_id=None),
+                name="Button",
+                event_type="double_press",
+                event_properties=None,
+            ),
+        },
+    )
+
+    # long press
+    data_string = bytes.fromhex("5859bb3811b26a1a38c1a4efb8ee2a0000604fc66f")
+    advertisement = bytes_to_service_info(data_string, address="A4:C1:38:1A:6A:B2")
+    assert device.update(advertisement) == SensorUpdate(
+        title="Button 6AB2 (PTX_YK1_QMIMB)",
+        devices={
+            None: SensorDeviceInfo(
+                name="Button 6AB2",
+                manufacturer="Xiaomi",
+                model="PTX_YK1_QMIMB",
+                hw_version=None,
+                sw_version="Xiaomi (MiBeacon V5 encrypted)",
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement="dBm",
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
+            ),
+        },
+        events={
+            DeviceKey(key="button", device_id=None): Event(
+                device_key=DeviceKey(key="button", device_id=None),
+                name="Button",
+                event_type="long_press",
+                event_properties=None,
+            ),
+        },
+    )
+
+
 def test_Xiaomi_XMZNMS08LM_door():
     """Test Xiaomi parser for XMZNMS08LM."""
     bindkey = "2c3795afa33019a8afdc17ba99e6f217"


### PR DESCRIPTION
A cheap wireless switch button from PTX
[Spec](https://home.miot-spec.com/s/090615.remote.btsw1) and [Introduction](https://home.mi.com/views/introduction.html?region=cn&pdid=14523&model=090615.remote.btsw1)

Xiaomi Cloud Tokens Extractor info:
```
   NAME:     PTX wireless switch(bluetooth version)
   BLE KEY:  6fb3f0c214eef4f7ad78467d9aa5fc16
   MAC:      A4:C1:38:1A:6A:B2
   MODEL:    090615.remote.btsw1
```

Event and Service Data:
```
Press
5859bb380fb26a1a38c1a46756c02a0000e75ef84c
decrypt object 0C4A00

Double Press
5859bb3810b26a1a38c1a433ea1b2a0000bad2e4b6
decrypt object 0D4A00

Long Press
5859bb3811b26a1a38c1a4efb8ee2a0000604fc66f
decrypt object 0E4A00

BLE KEY: 6fb3f0c214eef4f7ad78467d9aa5fc16
```

---
## Question:
As above, it seems that the data sent by this device is shorter than others,
which makes obj_length = 0, so the data could not be updated.
I removed [this judgment](https://github.com/Bluetooth-Devices/xiaomi-ble/blob/7fb82879ebd76353377c542c3950c622793e27a8/src/xiaomi_ble/parser.py#L1716), not sure if there are other implications, hopefully there is a better way to do it.

I tested it in the latest version of HA (2024.2.2), also simulated a XMWXKG01YL by esp32 and it works fine.

Thanks.