### PR TITLE
fix: handle jagged stairstep for LYWSD03MMC humidity

### DIFF
--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -718,7 +718,14 @@ def obj1006(
     """Humidity"""
     if len(xobj) == 2:
         (humi,) = H_STRUCT.unpack(xobj)
-        device.update_predefined_sensor(SensorLibrary.HUMIDITY__PERCENTAGE, humi / 10)
+        if device_type in ["LYWSD03MMC", "MHO-C401"]:                                 
+            # To handle jagged stair stepping readings from these sensors.                     
+            # https://github.com/custom-components/ble_monitor/blob/ef2e3944b9c1a635208390b8563710d0eec2a945/custom_components/ble_monitor/sensor.py#L752 
+            # https://github.com/esphome/esphome/blob/c39f6d0738d97ecc11238220b493731ec70c701c/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp#L44C14-L44C99 
+            # https://github.com/custom-components/ble_monitor/issues/7#issuecomment-595948254                                                            
+            device.update_predefined_sensor(SensorLibrary.HUMIDITY__PERCENTAGE, int(humi / 10))
+        else:
+            device.update_predefined_sensor(SensorLibrary.HUMIDITY__PERCENTAGE, humi / 10)
     return {}
 
 

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -718,11 +718,11 @@ def obj1006(
     """Humidity"""
     if len(xobj) == 2:
         (humi,) = H_STRUCT.unpack(xobj)
-        if device_type in ["LYWSD03MMC", "MHO-C401"]:                                 
-            # To handle jagged stair stepping readings from these sensors.                     
-            # https://github.com/custom-components/ble_monitor/blob/ef2e3944b9c1a635208390b8563710d0eec2a945/custom_components/ble_monitor/sensor.py#L752 
-            # https://github.com/esphome/esphome/blob/c39f6d0738d97ecc11238220b493731ec70c701c/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp#L44C14-L44C99 
-            # https://github.com/custom-components/ble_monitor/issues/7#issuecomment-595948254                                                            
+        if device_type in ["LYWSD03MMC", "MHO-C401"]:
+            # To handle jagged stair stepping readings from these sensors.
+            # https://github.com/custom-components/ble_monitor/blob/ef2e3944b9c1a635208390b8563710d0eec2a945/custom_components/ble_monitor/sensor.py#L752
+            # https://github.com/esphome/esphome/blob/c39f6d0738d97ecc11238220b493731ec70c701c/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp#L44C14-L44C99
+            # https://github.com/custom-components/ble_monitor/issues/7#issuecomment-595948254
             device.update_predefined_sensor(SensorLibrary.HUMIDITY__PERCENTAGE, int(humi / 10))
         else:
             device.update_predefined_sensor(SensorLibrary.HUMIDITY__PERCENTAGE, humi / 10)

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -723,9 +723,13 @@ def obj1006(
             # https://github.com/custom-components/ble_monitor/blob/ef2e3944b9c1a635208390b8563710d0eec2a945/custom_components/ble_monitor/sensor.py#L752
             # https://github.com/esphome/esphome/blob/c39f6d0738d97ecc11238220b493731ec70c701c/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp#L44C14-L44C99
             # https://github.com/custom-components/ble_monitor/issues/7#issuecomment-595948254
-            device.update_predefined_sensor(SensorLibrary.HUMIDITY__PERCENTAGE, int(humi / 10))
+            device.update_predefined_sensor(
+                SensorLibrary.HUMIDITY__PERCENTAGE, int(humi / 10)
+            )
         else:
-            device.update_predefined_sensor(SensorLibrary.HUMIDITY__PERCENTAGE, humi / 10)
+            device.update_predefined_sensor(
+                SensorLibrary.HUMIDITY__PERCENTAGE, humi / 10
+            )
     return {}
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -662,7 +662,7 @@ def test_Xiaomi_LYWSD03MMC_encrypted():
         },
         entity_values={
             KEY_HUMIDITY: SensorValue(
-                name="Humidity", device_key=KEY_HUMIDITY, native_value=46.7
+                name="Humidity", device_key=KEY_HUMIDITY, native_value=46
             ),
             KEY_SIGNAL_STRENGTH: SensorValue(
                 name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60


### PR DESCRIPTION
I noticed when using the esphome ble proxies for humidity data from LYWSD03MMC sensors, the values would stair step up in .1% increments until .9, then fall back to .0. I did not see this behavior when using the native esphome support for these sensors.   In the bluetooth channel in the HA discord,  Jc2k recalled that the ble_monitor custom component handled this but it was not ported over.  With that in mind I found references to code that worked around this behavior in the ble_monitor custom component and the native esphome sensor for these devices.  I've noted the links as comments in the code.

The ble_monitor code accounted for firmware version but I didn't see how to reference firmware version in the parser.py.
I'm happy to adjust but may need some help.


