### PR TITLE
feat: add support for Linptech RS1BB(MI)

### DIFF
--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -81,6 +81,10 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         name="Motion Sensor",
         model="HS1BB(MI)",
     ),
+        0x3F0F: DeviceEntry(
+        name="Flood and Rain Sensor",
+        model="RS1BB(MI)"
+    ),
     0x01AA: DeviceEntry(
         name="Temperature/Humidity Sensor",
         model="LYWSDCGQ",
@@ -252,10 +256,6 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
     0x0DE7: DeviceEntry(
         name="Odor Eliminator",
         model="SU001-T",
-    ),
-    0x3F0F: DeviceEntry(
-        name="Flood and Rain Sensor",
-        model="RS1BB"
     ),
 }
 

--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -81,10 +81,7 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         name="Motion Sensor",
         model="HS1BB(MI)",
     ),
-        0x3F0F: DeviceEntry(
-        name="Flood and Rain Sensor",
-        model="RS1BB(MI)"
-    ),
+    0x3F0F: DeviceEntry(name="Flood and Rain Sensor", model="RS1BB(MI)"),
     0x01AA: DeviceEntry(
         name="Temperature/Humidity Sensor",
         model="LYWSDCGQ",

--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -253,6 +253,10 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         name="Odor Eliminator",
         model="SU001-T",
     ),
+    0x3F0F: DeviceEntry(
+        name="Flood and Rain Sensor",
+        model="RS1BB"
+    ),
 }
 
 

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1044,7 +1044,9 @@ def obj4805(
     return {}
 
 
-def obj4806(xobj):
+def obj4806(
+     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
+) -> dict[str, Any]:
     """Moisture"""
     device.update_predefined_binary_sensor(
         BinarySensorDeviceClass.MOISTURE, xobj[0] > 0

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1045,13 +1045,14 @@ def obj4805(
 
 
 def obj4806(
-     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
+    xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
 ) -> dict[str, Any]:
     """Moisture"""
     device.update_predefined_binary_sensor(
         BinarySensorDeviceClass.MOISTURE, xobj[0] > 0
     )
     return {}
+
 
 def obj4818(
     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1044,6 +1044,13 @@ def obj4805(
     return {}
 
 
+def obj4806(xobj):
+    """Moisture"""
+    device.update_predefined_binary_sensor(
+        BinarySensorDeviceClass.MOISTURE, xobj[0] > 0
+    )
+    return {}
+
 def obj4818(
     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
 ) -> dict[str, Any]:
@@ -1428,6 +1435,7 @@ xiaomi_dataobject_dict = {
     0x4803: obj4803,
     0x4804: obj4804,
     0x4805: obj4805,
+    0x4806: obj4806,
     0x4818: obj4818,
     0x4A01: obj4a01,
     0x4A08: obj4a08,

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1630,7 +1630,7 @@ class XiaomiBluetoothDeviceData(BluetoothData):
             xiaomi_mac = xiaomi_mac_reversed[::-1]
             if xiaomi_mac != source_mac:
                 _LOGGER.debug(
-                    "MAC address doesn't match data frame. Expected: %s, Got: %s)",
+                    "MAC address doesn't match data frame. Expected: %s, Got: %s",
                     to_mac(xiaomi_mac),
                     to_mac(source_mac),
                 )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2482,6 +2482,7 @@ def test_Xiaomi_MS1BB_MI_obj4a13():
         },
     )
 
+
 def test_Xiaomi_RS1BB_MI_obj4806():
     """Test Xiaomi parser for Linptech RS1BB(MI) with obj4806."""
     data_string = b"XY\x0f?JgL\xb98\xc1\xa4\xd6\xe5{\x83\x04\x00\x00\xd0\x1e\x0bK"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2492,10 +2492,10 @@ def test_Xiaomi_RS1BB_MI_obj4806():
     assert device.supported(advertisement)
     assert device.bindkey_verified
     assert device.update(advertisement) == SensorUpdate(
-        title="Flood and Rain Sensor 4C67 (RS1BB)",
+        title="Flood and Rain Sensor 4C67 (RS1BB(MI))",
         devices={
             None: SensorDeviceInfo(
-                name="Flood and Rain Sensor",
+                name="Flood and Rain Sensor 4C67",
                 manufacturer="Xiaomi",
                 model="RS1BB(MI)",
                 hw_version=None,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2485,7 +2485,7 @@ def test_Xiaomi_MS1BB_MI_obj4a13():
 def test_Xiaomi_RS1BB_MI_obj4806():
     """Test Xiaomi parser for Linptech RS1BB(MI) with obj4806."""
     data_string = b"XY\x0f?JgL\xb98\xc1\xa4\xd6\xe5{\x83\x04\x00\x00\xd0\x1e\x0bK"
-    advertisement = bytes_to_service_info(data_string, address="A4:C1:38:66:E5:67")
+    advertisement = bytes_to_service_info(data_string, address="A4:C1:38:B9:4C:67")
     bindkey = "33ede53321bc73c790a8daae4581f3d5"
 
     device = XiaomiBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2484,7 +2484,7 @@ def test_Xiaomi_MS1BB_MI_obj4a13():
 
 def test_Xiaomi_RS1BB_MI_obj4806():
     """Test Xiaomi parser for Linptech RS1BB(MI) with obj4806."""
-    data_string = b"\x04>)\x02\x01\x00\x00gL\xb98\xc1\xa4\x1d\x02\x01\x06\x19\x16\x95\xfeXY\x0f?JgL\xb98\xc1\xa4\xd6\xe5{\x83\x04\x00\x00\xd0\x1e\x0bK\xc0"
+    data_string = b"XY\x0f?JgL\xb98\xc1\xa4\xd6\xe5{\x83\x04\x00\x00\xd0\x1e\x0bK"
     advertisement = bytes_to_service_info(data_string, address="A4:C1:38:66:E5:67")
     bindkey = "33ede53321bc73c790a8daae4581f3d5"
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2515,13 +2515,13 @@ def test_Xiaomi_RS1BB_MI_obj4806():
             ),
         },
         binary_entity_descriptions={
-            KEY_SMOKE: BinarySensorDescription(
+            KEY_MOISTURE: BinarySensorDescription(
                 device_key=KEY_MOISTURE,
                 device_class=BinarySensorDeviceClass.MOISTURE,
             ),
         },
         binary_entity_values={
-            KEY_SMOKE: BinarySensorValue(
+            KEY_MOISTURE: BinarySensorValue(
                 name="Moisture", device_key=KEY_MOISTURE, native_value=False
             ),
         },

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2482,6 +2482,51 @@ def test_Xiaomi_MS1BB_MI_obj4a13():
         },
     )
 
+def test_Xiaomi_RS1BB_MI_obj4806():
+    """Test Xiaomi parser for Linptech RS1BB(MI) with obj4806."""
+    data_string = b"\x04>)\x02\x01\x00\x00gL\xb98\xc1\xa4\x1d\x02\x01\x06\x19\x16\x95\xfeXY\x0f?JgL\xb98\xc1\xa4\xd6\xe5{\x83\x04\x00\x00\xd0\x1e\x0bK\xc0"
+    advertisement = bytes_to_service_info(data_string, address="A4:C1:38:66:E5:67")
+    bindkey = "33ede53321bc73c790a8daae4581f3d5"
+
+    device = XiaomiBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
+    assert device.supported(advertisement)
+    assert device.bindkey_verified
+    assert device.update(advertisement) == SensorUpdate(
+        title="Flood and Rain Sensor (RS1BB(MI))",
+        devices={
+            None: SensorDeviceInfo(
+                name="Flood and Rain Sensor",
+                manufacturer="Xiaomi",
+                model="RS1BB(MI)",
+                hw_version=None,
+                sw_version="Xiaomi (MiBeacon V5 encrypted)",
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement="dBm",
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-64
+            ),
+        },
+        binary_entity_descriptions={
+            KEY_SMOKE: BinarySensorDescription(
+                device_key=KEY_MOISTURE,
+                device_class=BinarySensorDeviceClass.MOISTURE,
+            ),
+        },
+        binary_entity_values={
+            KEY_SMOKE: BinarySensorValue(
+                name="Moisture", device_key=KEY_MOISTURE, native_value=False
+            ),
+        },
+    )
+
 
 def test_Xiaomi_XMWXKG01YL():
     """Test Xiaomi parser for XMWXKG01YL Switch (double button)."""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2492,7 +2492,7 @@ def test_Xiaomi_RS1BB_MI_obj4806():
     assert device.supported(advertisement)
     assert device.bindkey_verified
     assert device.update(advertisement) == SensorUpdate(
-        title="Flood and Rain Sensor (RS1BB(MI))",
+        title="Flood and Rain Sensor 4C67 (RS1BB)",
         devices={
             None: SensorDeviceInfo(
                 name="Flood and Rain Sensor",
@@ -2511,7 +2511,7 @@ def test_Xiaomi_RS1BB_MI_obj4806():
         },
         entity_values={
             KEY_SIGNAL_STRENGTH: SensorValue(
-                name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-64
+                name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
             ),
         },
         binary_entity_descriptions={


### PR DESCRIPTION
Attempt to add support for RS1BB(MI) in [xiaomi-ble](https://github.com/Bluetooth-Devices/xiaomi-ble).

I'm not sure what is the best way to test this change, but I try to raise the PR anyway and will try to explore how to test it out.

This PR is based on the change made in ble_monitor by @Ernst79: https://github.com/custom-components/ble_monitor/pull/1300/commits/2b5e8ea496d543ec5100fcd4c0e34bc7942a299f