### PR TITLE
feat: extend HHCCJCY01 battery level reading to GCLS002

### DIFF
--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -2000,7 +2000,7 @@ class XiaomiBluetoothDeviceData(BluetoothData):
             # kind of device we are
             return False
 
-        if self.device_id != 0x0098:
+        if self.device_id not in [0x03BC, 0x0098]:
             return False
 
         return not last_poll or last_poll > TIMEOUT_1DAY
@@ -2009,7 +2009,7 @@ class XiaomiBluetoothDeviceData(BluetoothData):
         """
         Poll the device to retrieve any values we can't get from passive listening.
         """
-        if self.device_id == 0x0098:
+        if self.device_id in [0x03BC, 0x0098]:
             client = await establish_connection(
                 BleakClient, ble_device, ble_device.address
             )


### PR DESCRIPTION
Now using the same mechanism for fetching the battery level of GCLS002 (device id 0x03BC) that was already in place for HHCCJCY01 (device id 0x0098).

Tested locally:
<img width="676" alt="Scherm­afbeelding 2024-06-17 om 21 09 09" src="https://github.com/Bluetooth-Devices/xiaomi-ble/assets/2139952/20e89f14-d4a1-4570-8cdb-5a4523f85f60">

closes #78 