### PR TITLE
fix: add xmosb01xs as a sleepy device

### DIFF
--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -268,4 +268,5 @@ SLEEPY_DEVICE_MODELS = {
     "RTCGQ02LM",
     "MMC-W505",
     "RS1BB(MI)",
+    "XMOSB01XS",
 }

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3021,6 +3021,7 @@ def test_Xiaomi_XMOSB01XS_ILLUMINANCE():
     device = XiaomiBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
     assert device.supported(advertisement)
     assert device.bindkey_verified
+    assert device.sleepy_device
     assert device.update(advertisement) == SensorUpdate(
         title="Occupancy Sensor 411E (XMOSB01XS)",
         devices={
@@ -3069,6 +3070,7 @@ def test_Xiaomi_XMOSB01XS_OCCUPANCY():
     device = XiaomiBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
     assert device.supported(advertisement)
     assert device.bindkey_verified
+    assert device.sleepy_device
     assert device.update(advertisement) == SensorUpdate(
         title="Occupancy Sensor B1BD (XMOSB01XS)",
         devices={


### PR DESCRIPTION
this battery device is really a sleepy device.
it won't broadcast any occupancy message unless it is changed.