### PR TITLE
feat: support xiaomi motion sensor 2s - global version (XMPIR02SGXS)

### DIFF
--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -158,6 +158,10 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         name="Motion Sensor",
         model="XMPIRO2SXS",
     ),
+    0x4C60: DeviceEntry(
+        name="Motion Sensor",
+        model="XMPIRO2GSXS",
+    ),
     0x4683: DeviceEntry(
         name="Occupancy Sensor",
         model="XMOSB01XS",


### PR DESCRIPTION
It's actually the same as the China mainland version (XMPIR02SXS vs XMPIR02SGXS).
The only change is the device id as the code change indicates.
The change is manually verified by Home Assistant (no change except using the new xiaomi-ble package)

Hardware Info:
- https://www.mi.com/global/product/xiaomi-motion-sensor-2s/

![WX20240907-184558@2x](https://github.com/user-attachments/assets/fab53271-2e84-4e2f-b167-acb4d6086f68)
![WX20240907-183342@2x](https://github.com/user-attachments/assets/d8e383a3-3841-4220-be1f-7b259fdea065)
![WX20240907-183155@2x](https://github.com/user-attachments/assets/72cd4ace-2448-4cc0-af35-35d16c23be92)
