### PR TITLE
feat:  support Smart TH 3 mini (MJWSD06MMC)

### DIFF
--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -106,7 +106,7 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         name="Temperature/Humidity Sensor",
         model="MJWSD05MMC",
     ),
-    0x55b5: DeviceEntry(
+    0x55B5: DeviceEntry(
         name="Temperature/Humidity Sensor",
         model="MJWSD06MMC",
     ),

--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -106,6 +106,10 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         name="Temperature/Humidity Sensor",
         model="MJWSD05MMC",
     ),
+    0x55b5: DeviceEntry(
+        name="Temperature/Humidity Sensor",
+        model="MJWSD06MMC",
+    ),
     0x098B: DeviceEntry(
         name="Door/Window Sensor",
         model="MCCGQ02HL",

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -999,6 +999,25 @@ def obj3003(
         )
     return result
 
+# MJWSD06MMC
+def obj4801(
+    xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
+) -> dict[str, Any]:
+    """Temperature"""
+    if len(xobj) == 4:
+        temp = FLOAT_STRUCT.unpack(xobj)[0]
+        device.update_predefined_sensor(
+            SensorLibrary.TEMPERATURE__CELSIUS, round(temp, 2)
+        )
+    return {}
+
+# MJWSD06MMC
+def obj4802(
+    xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
+) -> dict[str, Any]:
+    """Humidity"""
+    device.update_predefined_sensor(SensorLibrary.HUMIDITY__PERCENTAGE, xobj[0])
+    return {}
 
 # The following data objects are device specific. For now only added for
 # LYWSD02MMC, MJWSD05MMC, XMWSDJ04MMC, XMWXKG01YL, LINPTECH MS1BB(MI), HS1BB(MI),
@@ -1477,6 +1496,8 @@ xiaomi_dataobject_dict = {
     0x101B: obj101b,
     0x2000: obj2000,
     0x3003: obj3003,
+    0x4801: obj4801,
+    0x4802: obj4802,
     0x4803: obj4803,
     0x4804: obj4804,
     0x4805: obj4805,

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -999,6 +999,7 @@ def obj3003(
         )
     return result
 
+
 # MJWSD06MMC
 def obj4801(
     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
@@ -1011,6 +1012,7 @@ def obj4801(
         )
     return {}
 
+
 # MJWSD06MMC
 def obj4802(
     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
@@ -1018,6 +1020,7 @@ def obj4802(
     """Humidity"""
     device.update_predefined_sensor(SensorLibrary.HUMIDITY__PERCENTAGE, xobj[0])
     return {}
+
 
 # The following data objects are device specific. For now only added for
 # LYWSD02MMC, MJWSD05MMC, XMWSDJ04MMC, XMWXKG01YL, LINPTECH MS1BB(MI), HS1BB(MI),


### PR DESCRIPTION
Add support Smart TH 3 mini (MJWSD06MMC)

- Added corresponding deveice id: 21893 (0x5585)
- Added two parsers: obj4801(Temperature) and obj4802(Humidity)


![63030d55182403edefae15e3084dcb08](https://github.com/user-attachments/assets/3ab3a7e6-c7e4-4d6c-910c-887914511263)
