### PR TITLE
feat: add more device types for the s400 body composition scale

### DIFF
--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -278,9 +278,21 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         name="Odor Eliminator",
         model="SU001-T",
     ),
+    0x30D9: DeviceEntry(
+        name="Body Composition Scale",
+        model="MJTZC01YM",
+    ),
     0x3BD5: DeviceEntry(
         name="Body Composition Scale",
         model="MJTZC01YM",
+    ),
+    0x48CF: DeviceEntry(
+        name="Body Composition Scale",
+        model="MJTZC01YM",
+    ),
+    0x4B05: DeviceEntry(
+        name="Body Composition Scale",
+        model="MJTZC03YM",
     ),
     0x5968: DeviceEntry(
         name="Switch (double button)",
@@ -298,5 +310,6 @@ SLEEPY_DEVICE_MODELS = {
     "RS1BB(MI)",
     "XMOSB01XS",
     "MJTZC01YM",
+    "MJTZC03YM",
     "HS1BB(MI)",
 }


### PR DESCRIPTION
These were taken from here:

https://github.com/AlexxIT/XiaomiGateway3/blob/d1727280fe45dcf0f921f950120886c0d8797a48/custom_components/xiaomi_gateway3/core/devices.py#L2108

This should fix #182.