### PR TITLE
feat: add support for Linptech ES3 human presence sensor

### DIFF
--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -294,6 +294,11 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         name="Body Composition Scale",
         model="MJTZC03YM",
     ),
+    0x50FB: DeviceEntry(
+        name="Human Presence Sensor",
+        model="ES3",
+        manufacturer="Linptech",
+    ),
     0x5968: DeviceEntry(
         name="Switch (double button)",
         model="XMWS01XS",
@@ -303,6 +308,7 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
 
 SLEEPY_DEVICE_MODELS = {
     "CGH1",
+    "ES3",
     "JTYJGD03MI",
     "MCCGQ02HL",
     "RTCGQ02LM",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3552,3 +3552,143 @@ def test_Xiaomi_XMWS01XS_long_press():
 
 def test_can_create():
     XiaomiBluetoothDeviceData()
+
+
+def test_Xiaomi_ES3_illuminance():
+    """Test Xiaomi parser for Linptech ES3 illuminance."""
+    data_string = b"HY\xfbP\xd9\x86\xd2~\x8fS\x13\xe9\x00\x00\x000\xadm\xa8"
+    advertisement = bytes_to_service_info(data_string, address="A4:C1:38:C7:C3:76")
+    bindkey = "b26295a7a08fbac306c8706ade7f0fe4"
+
+    device = XiaomiBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
+    assert device.supported(advertisement)
+    assert device.bindkey_verified
+    assert device.sleepy_device
+    assert device.update(advertisement) == SensorUpdate(
+        title="Human Presence Sensor C376 (ES3)",
+        devices={
+            None: SensorDeviceInfo(
+                name="Human Presence Sensor C376",
+                manufacturer="Linptech",
+                model="ES3",
+                hw_version=None,
+                sw_version="Xiaomi (MiBeacon V5 encrypted)",
+            )
+        },
+        entity_descriptions={
+            KEY_ILLUMINANCE: SensorDescription(
+                device_key=KEY_ILLUMINANCE,
+                device_class=DeviceClass.ILLUMINANCE,
+                native_unit_of_measurement=Units.LIGHT_LUX,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement="dBm",
+            ),
+        },
+        entity_values={
+            KEY_ILLUMINANCE: SensorValue(
+                name="Illuminance", device_key=KEY_ILLUMINANCE, native_value=173
+            ),
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
+            ),
+        },
+        binary_entity_descriptions={},
+        binary_entity_values={},
+    )
+
+
+def test_Xiaomi_ES3_occupancy_on():
+    """Test Xiaomi parser for Linptech ES3 occupancy detected."""
+    data_string = b"XY\xfbP\xdav\xc3\xc78\xc1\xa4\xaa\xbcL\x16\x00\x00\x00\xc6\x0c\x16F"
+    advertisement = bytes_to_service_info(data_string, address="A4:C1:38:C7:C3:76")
+    bindkey = "b26295a7a08fbac306c8706ade7f0fe4"
+
+    device = XiaomiBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
+    assert device.supported(advertisement)
+    assert device.bindkey_verified
+    assert device.sleepy_device
+    assert device.update(advertisement) == SensorUpdate(
+        title="Human Presence Sensor C376 (ES3)",
+        devices={
+            None: SensorDeviceInfo(
+                name="Human Presence Sensor C376",
+                manufacturer="Linptech",
+                model="ES3",
+                hw_version=None,
+                sw_version="Xiaomi (MiBeacon V5 encrypted)",
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement="dBm",
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
+            ),
+        },
+        binary_entity_descriptions={
+            KEY_BINARY_OCCUPANCY: BinarySensorDescription(
+                device_key=KEY_BINARY_OCCUPANCY,
+                device_class=BinarySensorDeviceClass.OCCUPANCY,
+            ),
+        },
+        binary_entity_values={
+            KEY_BINARY_OCCUPANCY: BinarySensorValue(
+                device_key=KEY_BINARY_OCCUPANCY, name="Occupancy", native_value=True
+            ),
+        },
+    )
+
+
+def test_Xiaomi_ES3_occupancy_off():
+    """Test Xiaomi parser for Linptech ES3 occupancy cleared."""
+    data_string = b"XY\xfbP2\x8a\x88\xa48\xc1\xa4E\x8a\x85\xb7\x96\x00\x00H\xfe\x13\xba"
+    advertisement = bytes_to_service_info(data_string, address="A4:C1:38:A4:88:8A")
+    bindkey = "fb352ea2139ab095877a9e2ae600c912"
+
+    device = XiaomiBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
+    assert device.supported(advertisement)
+    assert device.bindkey_verified
+    assert device.sleepy_device
+    assert device.update(advertisement) == SensorUpdate(
+        title="Human Presence Sensor 888A (ES3)",
+        devices={
+            None: SensorDeviceInfo(
+                name="Human Presence Sensor 888A",
+                manufacturer="Linptech",
+                model="ES3",
+                hw_version=None,
+                sw_version="Xiaomi (MiBeacon V5 encrypted)",
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement="dBm",
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
+            ),
+        },
+        binary_entity_descriptions={
+            KEY_BINARY_OCCUPANCY: BinarySensorDescription(
+                device_key=KEY_BINARY_OCCUPANCY,
+                device_class=BinarySensorDeviceClass.OCCUPANCY,
+            ),
+        },
+        binary_entity_values={
+            KEY_BINARY_OCCUPANCY: BinarySensorValue(
+                device_key=KEY_BINARY_OCCUPANCY, name="Occupancy", native_value=False
+            ),
+        },
+    )


### PR DESCRIPTION
  ## Description

  This PR adds support for the Linptech ES3 human presence sensor, a radar-based occupancy sensor that's functionally identical to the Xiaomi XMOSB01XS but manufactured by Linptech.

  ## Device Details

  - **Device ID**: 0x50FB
  - **Model**: ES3
  - **Manufacturer**: Linptech
  - **Type**: Human presence sensor
  - **Features**: Occupancy detection, illuminance measurement
  - **Encryption**: MiBeacon V5 encrypted

  ## Changes

  - Added ES3 to `DEVICE_TYPES` dictionary in `src/xiaomi_ble/devices.py`
  - Added ES3 to `SLEEPY_DEVICE_MODELS` set (battery-powered, event-based broadcasting)
  - Added 3 new tests covering:
    - Illuminance data parsing (173 lux)
    - Occupancy detected state
    - Occupancy cleared state

  ## Implementation Notes

  The ES3 implementation is based on the existing support in the [ble_monitor](https://github.com/custom-components/ble_monitor) custom component. The test data was extracted from real ES3 devices as captured in ble_monitor's test suite (`custom_components/ble_monitor/test/test_xiaomi_parser.py`).

  ## References

  - ES3 documentation in ble_monitor: [Linptech ES3.md](https://github.com/custom-components/ble_monitor/blob/master/docs/_devices/Linptech%20ES3.md)
  - Related ble_monitor code: [xiaomi.py#L85](https://github.com/custom-components/ble_monitor/blob/master/custom_components/ble_monitor/ble_parser/xiaomi.py#L85)
