### PR TITLE
feat: add support for Linptech PS1BB seat pressure sensor

### DIFF
--- a/src/xiaomi_ble/const.py
+++ b/src/xiaomi_ble/const.py
@@ -99,6 +99,12 @@ class ExtendedSensorDeviceClass(BaseDeviceClass):
     # Charging State
     CHARGING_STATE = "charging_state"
 
+    # Pressure Present Duration
+    PRESSURE_PRESENT_DURATION = "pressure_present_duration"
+
+    # Pressure Not Present Duration
+    PRESSURE_NOT_PRESENT_DURATION = "pressure_not_present_duration"
+
     # Sleep State
     SLEEP_STATE = "sleep_state"
 

--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -90,6 +90,11 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         model="HS1BB(MI)",
     ),
     0x3F0F: DeviceEntry(name="Flood and Rain Sensor", model="RS1BB(MI)"),
+    0x3F4C: DeviceEntry(
+        name="Seat Pressure Sensor",
+        model="PS1BB",
+        manufacturer="Linptech",
+    ),
     0x01AA: DeviceEntry(
         name="Temperature/Humidity Sensor",
         model="LYWSDCGQ",
@@ -336,6 +341,7 @@ SLEEPY_DEVICE_MODELS = {
     "CGH1",
     "ES3",
     "ES5BB",
+    "PS1BB",
     "JTYJGD03MI",
     "MCCGQ02HL",
     "RTCGQ02LM",

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1131,6 +1131,50 @@ def obj4818(
     return {}
 
 
+def obj483c(
+    xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
+) -> dict[str, Any]:
+    """Pressure Present State: uint8: 0 - No pressure, 1 - Pressure detected"""
+    if len(xobj) != 1:
+        return {}
+    device.update_predefined_binary_sensor(
+        BinarySensorDeviceClass.OCCUPANCY, xobj[0] > 0
+    )
+    return {}
+
+
+def obj483d(
+    xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
+) -> dict[str, Any]:
+    """Pressure Present Duration in seconds"""
+    if len(xobj) == 4:
+        (duration,) = struct.unpack("<I", xobj)
+        device.update_sensor(
+            key=ExtendedSensorDeviceClass.PRESSURE_PRESENT_DURATION,
+            name="Pressure present duration",
+            native_unit_of_measurement=Units.TIME_SECONDS,
+            device_class=ExtendedSensorDeviceClass.PRESSURE_PRESENT_DURATION,
+            native_value=duration,
+        )
+    return {}
+
+
+def obj483e(
+    xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
+) -> dict[str, Any]:
+    """Pressure Not Present Duration in seconds"""
+    if len(xobj) == 4:
+        (duration,) = struct.unpack("<I", xobj)
+        device.update_sensor(
+            key=ExtendedSensorDeviceClass.PRESSURE_NOT_PRESENT_DURATION,
+            name="Pressure not present duration",
+            native_unit_of_measurement=Units.TIME_SECONDS,
+            device_class=ExtendedSensorDeviceClass.PRESSURE_NOT_PRESENT_DURATION,
+            native_value=duration,
+        )
+    return {}
+
+
 def obj484e(
     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
 ) -> dict[str, Any]:
@@ -1830,6 +1874,9 @@ xiaomi_dataobject_dict = {
     0x4806: obj4806,
     0x4808: obj4808,
     0x4818: obj4818,
+    0x483C: obj483c,
+    0x483D: obj483d,
+    0x483E: obj483e,
     0x484E: obj484e,
     0x4851: obj4851,
     0x4852: obj4852,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -74,6 +74,12 @@ KEY_SLEEP_STATE = DeviceKey(key="sleep_state", device_id=None)
 KEY_DEVICE_WEARING_STATUS = DeviceKey(key="device_wearing_status", device_id=None)
 KEY_DURATION_DETECTED = DeviceKey(key="duration_detected", device_id=None)
 KEY_DURATION_CLEARED = DeviceKey(key="duration_cleared", device_id=None)
+KEY_PRESSURE_PRESENT_DURATION = DeviceKey(
+    key="pressure_present_duration", device_id=None
+)
+KEY_PRESSURE_NOT_PRESENT_DURATION = DeviceKey(
+    key="pressure_not_present_duration", device_id=None
+)
 
 
 @pytest.fixture(autouse=True)
@@ -4606,6 +4612,252 @@ def test_Xiaomi_ES5BB_duration_cleared():
                 device_key=KEY_DURATION_CLEARED,
                 name="Duration cleared",
                 native_value=1,
+            ),
+        },
+    )
+
+
+def test_Xiaomi_PS1BB_pressure_present_duration():
+    """Test Xiaomi parser for Linptech PS1BB Pressure Present Duration."""
+    data_string = bytes.fromhex("59584c3f2012efbe38c1a4bbacc927535b030000004cdc48fd")
+    advertisement = bytes_to_service_info(data_string, address="A4:C1:38:BE:EF:12")
+    bindkey = "8b72476b60fe2a0b63bf58d588fe4ea1"
+
+    device = XiaomiBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
+    assert device.supported(advertisement)
+    assert device.bindkey_verified
+    assert device.sleepy_device
+    assert device.update(advertisement) == SensorUpdate(
+        title="Seat Pressure Sensor EF12 (PS1BB)",
+        devices={
+            None: SensorDeviceInfo(
+                name="Seat Pressure Sensor EF12",
+                manufacturer="Linptech",
+                model="PS1BB",
+                hw_version=None,
+                sw_version="Xiaomi (MiBeacon V5 encrypted)",
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement="dBm",
+            ),
+            KEY_PRESSURE_PRESENT_DURATION: SensorDescription(
+                device_key=KEY_PRESSURE_PRESENT_DURATION,
+                device_class=ExtendedSensorDeviceClass.PRESSURE_PRESENT_DURATION,
+                native_unit_of_measurement="s",
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength",
+                device_key=KEY_SIGNAL_STRENGTH,
+                native_value=-60,
+            ),
+            KEY_PRESSURE_PRESENT_DURATION: SensorValue(
+                device_key=KEY_PRESSURE_PRESENT_DURATION,
+                name="Pressure present duration",
+                native_value=7800,
+            ),
+        },
+    )
+
+
+def test_Xiaomi_PS1BB_pressure_state_occupied():
+    """Test Xiaomi parser for Linptech PS1BB pressure state occupied."""
+    data_string = bytes.fromhex("58594c3f1012efbe38c1a47f7b3e9500000035019b75")
+    advertisement = bytes_to_service_info(data_string, address="A4:C1:38:BE:EF:12")
+    bindkey = "8b72476b60fe2a0b63bf58d588fe4ea1"
+
+    device = XiaomiBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
+    assert device.supported(advertisement)
+    assert device.bindkey_verified
+    assert device.sleepy_device
+    assert device.update(advertisement) == SensorUpdate(
+        title="Seat Pressure Sensor EF12 (PS1BB)",
+        devices={
+            None: SensorDeviceInfo(
+                name="Seat Pressure Sensor EF12",
+                manufacturer="Linptech",
+                model="PS1BB",
+                hw_version=None,
+                sw_version="Xiaomi (MiBeacon V5 encrypted)",
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement="dBm",
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength",
+                device_key=KEY_SIGNAL_STRENGTH,
+                native_value=-60,
+            ),
+        },
+        binary_entity_descriptions={
+            KEY_BINARY_OCCUPANCY: BinarySensorDescription(
+                device_key=KEY_BINARY_OCCUPANCY,
+                device_class=BinarySensorDeviceClass.OCCUPANCY,
+            ),
+        },
+        binary_entity_values={
+            KEY_BINARY_OCCUPANCY: BinarySensorValue(
+                device_key=KEY_BINARY_OCCUPANCY,
+                name="Occupancy",
+                native_value=True,
+            ),
+        },
+    )
+
+
+def test_Xiaomi_PS1BB_pressure_state_clear():
+    """Test Xiaomi parser for Linptech PS1BB pressure state clear."""
+    data_string = bytes.fromhex("58594c3f1312efbe38c1a418e36bcb000000e6fab951")
+    advertisement = bytes_to_service_info(data_string, address="A4:C1:38:BE:EF:12")
+    bindkey = "8b72476b60fe2a0b63bf58d588fe4ea1"
+
+    device = XiaomiBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
+    assert device.supported(advertisement)
+    assert device.bindkey_verified
+    assert device.sleepy_device
+    assert device.update(advertisement) == SensorUpdate(
+        title="Seat Pressure Sensor EF12 (PS1BB)",
+        devices={
+            None: SensorDeviceInfo(
+                name="Seat Pressure Sensor EF12",
+                manufacturer="Linptech",
+                model="PS1BB",
+                hw_version=None,
+                sw_version="Xiaomi (MiBeacon V5 encrypted)",
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement="dBm",
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength",
+                device_key=KEY_SIGNAL_STRENGTH,
+                native_value=-60,
+            ),
+        },
+        binary_entity_descriptions={
+            KEY_BINARY_OCCUPANCY: BinarySensorDescription(
+                device_key=KEY_BINARY_OCCUPANCY,
+                device_class=BinarySensorDeviceClass.OCCUPANCY,
+            ),
+        },
+        binary_entity_values={
+            KEY_BINARY_OCCUPANCY: BinarySensorValue(
+                device_key=KEY_BINARY_OCCUPANCY,
+                name="Occupancy",
+                native_value=False,
+            ),
+        },
+    )
+
+
+def test_Xiaomi_PS1BB_pressure_not_present_duration():
+    """Test Xiaomi parser for Linptech PS1BB pressure not present duration."""
+    data_string = bytes.fromhex("59584c3f2112efbe38c1a4558db5277810330000001906bc63")
+    advertisement = bytes_to_service_info(data_string, address="A4:C1:38:BE:EF:12")
+    bindkey = "8b72476b60fe2a0b63bf58d588fe4ea1"
+
+    device = XiaomiBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
+    assert device.supported(advertisement)
+    assert device.bindkey_verified
+    assert device.sleepy_device
+    assert device.update(advertisement) == SensorUpdate(
+        title="Seat Pressure Sensor EF12 (PS1BB)",
+        devices={
+            None: SensorDeviceInfo(
+                name="Seat Pressure Sensor EF12",
+                manufacturer="Linptech",
+                model="PS1BB",
+                hw_version=None,
+                sw_version="Xiaomi (MiBeacon V5 encrypted)",
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement="dBm",
+            ),
+            KEY_PRESSURE_NOT_PRESENT_DURATION: SensorDescription(
+                device_key=KEY_PRESSURE_NOT_PRESENT_DURATION,
+                device_class=ExtendedSensorDeviceClass.PRESSURE_NOT_PRESENT_DURATION,
+                native_unit_of_measurement="s",
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength",
+                device_key=KEY_SIGNAL_STRENGTH,
+                native_value=-60,
+            ),
+            KEY_PRESSURE_NOT_PRESENT_DURATION: SensorValue(
+                device_key=KEY_PRESSURE_NOT_PRESENT_DURATION,
+                name="Pressure not present duration",
+                native_value=120,
+            ),
+        },
+    )
+
+
+def test_Xiaomi_PS1BB_battery():
+    """Test Xiaomi parser for Linptech PS1BB battery."""
+    data_string = bytes.fromhex("59584c3f2212efbe38c1a4da2cec2100000029c7c0c7")
+    advertisement = bytes_to_service_info(data_string, address="A4:C1:38:BE:EF:12")
+    bindkey = "8b72476b60fe2a0b63bf58d588fe4ea1"
+
+    device = XiaomiBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
+    assert device.supported(advertisement)
+    assert device.bindkey_verified
+    assert device.sleepy_device
+    assert device.update(advertisement) == SensorUpdate(
+        title="Seat Pressure Sensor EF12 (PS1BB)",
+        devices={
+            None: SensorDeviceInfo(
+                name="Seat Pressure Sensor EF12",
+                manufacturer="Linptech",
+                model="PS1BB",
+                hw_version=None,
+                sw_version="Xiaomi (MiBeacon V5 encrypted)",
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement="dBm",
+            ),
+            KEY_BATTERY: SensorDescription(
+                device_key=KEY_BATTERY,
+                device_class=DeviceClass.BATTERY,
+                native_unit_of_measurement="%",
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength",
+                device_key=KEY_SIGNAL_STRENGTH,
+                native_value=-60,
+            ),
+            KEY_BATTERY: SensorValue(
+                device_key=KEY_BATTERY,
+                name="Battery",
+                native_value=100,
             ),
         },
     )


### PR DESCRIPTION
Adds support for the Linptech PS1BB seat pressure sensor (`0x3F4C`).

Closes #273

Parser logic is based on [ble_monitor#1368](https://github.com/custom-components/ble_monitor/pull/1368) by @Ernst79, who figured out the object IDs and payload formats.

### What changed

- `devices.py` — new device entry + sleepy model registration
- `const.py` — two new `ExtendedSensorDeviceClass` values for pressure durations
- `parser.py` — three MiBeacon V5 handlers: pressure state (0x483C, occupancy binary sensor), present duration (0x483D), not-present duration (0x483E)
- `test_parser.py` — five tests covering occupancy on/off, both durations, and battery

Tested on a real PS1BB device.
