### PR TITLE
Add 0x45C9 for MJTZC02YM

### DIFF
--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -291,6 +291,10 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         name="Body Composition Scale",
         model="MJTZC01YM",
     ),
+    0x45C9: DeviceEntry(
+        name="Smart Scale S200",
+        model="MJTZC02YM",
+    ),
     0x48CF: DeviceEntry(
         name="Body Composition Scale",
         model="MJTZC01YM",


### PR DESCRIPTION
```json
{
  "name": "yunmai.scales.ms106",
  "address": "XX",
  "rssi": -67,
  "manufacturer_data": {},
  "service_data": {
    "0000fe95-0000-1000-8000-00805f9b34fb": "105bc945....7bd0"
  },
  "service_uuids": [],
  "source": "XX",
  "connectable": true,
  "time": 1776354561.5659854,
  "tx_power": null,
  "raw": "..."
}

```