### PR TITLE
Add Support for USP Door/Window binarysensor

### DIFF
--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1111,7 +1111,10 @@ def obj4808(
     device.update_predefined_sensor(SensorLibrary.HUMIDITY__PERCENTAGE, round(humi, 1))
     return {}
 
-def obj480c(xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str) -> dict[str, Any]:
+
+def obj480c(
+    xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
+) -> dict[str, Any]:
     """Door/Window state for zhiee.magnet.mc01 and similar devices."""
     if len(xobj) != 1:
         return {}
@@ -1121,6 +1124,7 @@ def obj480c(xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str) ->
     elif state == 0x01:
         device.update_predefined_binary_sensor(BinarySensorDeviceClass.OPENING, False)
     return {}
+
 
 def obj4818(
     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1111,6 +1111,16 @@ def obj4808(
     device.update_predefined_sensor(SensorLibrary.HUMIDITY__PERCENTAGE, round(humi, 1))
     return {}
 
+def obj480c(xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str) -> dict[str, Any]:
+    """Door/Window state for zhiee.magnet.mc01 and similar devices."""
+    if len(xobj) != 1:
+        return {}
+    state = xobj[0]
+    if state == 0x00:
+        device.update_predefined_binary_sensor(BinarySensorDeviceClass.OPENING, True)
+    elif state == 0x01:
+        device.update_predefined_binary_sensor(BinarySensorDeviceClass.OPENING, False)
+    return {}
 
 def obj4818(
     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
@@ -1861,6 +1871,7 @@ xiaomi_dataobject_dict = {
     0x4805: obj4805,
     0x4806: obj4806,
     0x4808: obj4808,
+    0x480C: obj480c,
     0x4818: obj4818,
     0x483C: obj483c,
     0x483D: obj483d,


### PR DESCRIPTION
USP Door/Window Object is 0x480c，Add obj480c function for Door/Window state, Now，I have successfully owned the entity binarysensor and the status is normal.