### PR TITLE
feat(parser): add impedance_high and stabilized binary sensor for S400

### DIFF
--- a/src/xiaomi_ble/const.py
+++ b/src/xiaomi_ble/const.py
@@ -56,6 +56,9 @@ class ExtendedBinarySensorDeviceClass(BaseDeviceClass):
     # On means door pried, Off means door not pried
     PRY_THE_DOOR = "pry_the_door"
 
+    # On means measurement stabilized, Off means measuring or stepped off
+    STABILIZED = "stabilized"
+
     # On means toothbrush On, Off means toothbrush Off
     TOOTHBRUSH = "toothbrush"
 
@@ -96,8 +99,11 @@ class ExtendedSensorDeviceClass(BaseDeviceClass):
     # No-One-Duration
     DURATION_CLEARED = "duration_cleared"
 
-    # Low frequency impedance
+    # Low frequency impedance 50 kHz
     IMPEDANCE_LOW = "impedance_low"
+
+    # High frequency impedance 250 kHz
+    IMPEDANCE_HIGH = "impedance_high"
 
     # Heart rate
     HEART_RATE = "heart_rate"

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1798,11 +1798,28 @@ def obj6e16(
 ) -> dict[str, Any]:
     """Body Composition Scale S400"""
     profile_id, data, _ = struct.unpack("<BII", xobj)
-    if not data:
-        return {}
     mass = data & 0x7FF
     heart_rate = (data >> 11) & 0x7F
     impedance = data >> 18
+
+    device.update_sensor(
+        key=ExtendedSensorDeviceClass.PROFILE_ID,
+        name="Profile ID",
+        device_class=ExtendedSensorDeviceClass.PROFILE_ID,
+        native_unit_of_measurement=None,
+        native_value=profile_id,
+    )
+
+    if mass == 0 and heart_rate == 0 and impedance == 0:
+        # Person stepped off the scale → reset
+        device.update_binary_sensor(
+            key=ExtendedBinarySensorDeviceClass.STABILIZED,
+            name="Stabilized",
+            device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            native_value=False,
+        )
+        return {}
+
     if mass != 0:
         device.update_predefined_sensor(SensorLibrary.MASS__MASS_KILOGRAMS, mass / 10)
     if 0 < heart_rate < 127:
@@ -1814,15 +1831,7 @@ def obj6e16(
             native_value=heart_rate + 50,
         )
 
-    if mass == 0 and heart_rate == 0 and impedance == 0:
-        # Person stepped off the scale
-        device.update_binary_sensor(
-            key=ExtendedBinarySensorDeviceClass.STABILIZED,
-            name="Stabilized",
-            device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
-            native_value=False,
-        )
-    elif mass == 0 and heart_rate == 0:
+    if mass == 0 and heart_rate == 0:
         # Last packet → high frequency 250 kHz → impedance_high → stabilized
         device.update_sensor(
             key=ExtendedSensorDeviceClass.IMPEDANCE_HIGH,
@@ -1861,13 +1870,6 @@ def obj6e16(
             native_value=True,
         )
 
-    device.update_sensor(
-        key=ExtendedSensorDeviceClass.PROFILE_ID,
-        name="Profile ID",
-        device_class=ExtendedSensorDeviceClass.PROFILE_ID,
-        native_unit_of_measurement=None,
-        native_value=profile_id,
-    )
     return {}
 
 

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1813,19 +1813,54 @@ def obj6e16(
             native_unit_of_measurement="bpm",
             native_value=heart_rate + 50,
         )
-    if impedance != 0:
-        if mass != 0:
-            device.update_predefined_sensor(
-                SensorLibrary.IMPEDANCE__OHM, impedance / 10
-            )
-        else:
-            device.update_sensor(
-                key=ExtendedSensorDeviceClass.IMPEDANCE_LOW,
-                name="Impedance Low",
-                device_class=ExtendedSensorDeviceClass.IMPEDANCE_LOW,
-                native_unit_of_measurement=Units.OHM,
-                native_value=impedance / 10,
-            )
+
+    if mass == 0 and heart_rate == 0 and impedance == 0:
+        # Person stepped off the scale
+        device.update_binary_sensor(
+            key=ExtendedBinarySensorDeviceClass.STABILIZED,
+            name="Stabilized",
+            device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            native_value=False,
+        )
+    elif mass == 0 and heart_rate == 0:
+        # Last packet → high frequency 250 kHz → impedance_high → stabilized
+        device.update_sensor(
+            key=ExtendedSensorDeviceClass.IMPEDANCE_HIGH,
+            name="Impedance High",
+            device_class=ExtendedSensorDeviceClass.IMPEDANCE_HIGH,
+            native_unit_of_measurement=Units.OHM,
+            native_value=impedance / 10,
+        )
+        device.update_binary_sensor(
+            key=ExtendedBinarySensorDeviceClass.STABILIZED,
+            name="Stabilized",
+            device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            native_value=True,
+        )
+    elif impedance != 0:
+        # Packet with weight → low frequency 50 kHz → impedance_low
+        device.update_sensor(
+            key=ExtendedSensorDeviceClass.IMPEDANCE_LOW,
+            name="Impedance Low",
+            device_class=ExtendedSensorDeviceClass.IMPEDANCE_LOW,
+            native_unit_of_measurement=Units.OHM,
+            native_value=impedance / 10,
+        )
+        device.update_binary_sensor(
+            key=ExtendedBinarySensorDeviceClass.STABILIZED,
+            name="Stabilized",
+            device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            native_value=False,
+        )
+    else:
+        # Packet with weight only → with socks → stabilized
+        device.update_binary_sensor(
+            key=ExtendedBinarySensorDeviceClass.STABILIZED,
+            name="Stabilized",
+            device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            native_value=True,
+        )
+
     device.update_sensor(
         key=ExtendedSensorDeviceClass.PROFILE_ID,
         name="Profile ID",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -65,8 +65,10 @@ KEY_SIGNAL_STRENGTH = DeviceKey(key="signal_strength", device_id=None)
 KEY_SMOKE = DeviceKey(key="smoke", device_id=None)
 KEY_TEMPERATURE = DeviceKey(key="temperature", device_id=None)
 KEY_IMPEDANCE_LOW = DeviceKey(key="impedance_low", device_id=None)
+KEY_IMPEDANCE_HIGH = DeviceKey(key="impedance_high", device_id=None)
 KEY_HEART_RATE = DeviceKey(key="heart_rate", device_id=None)
 KEY_PROFILE_ID = DeviceKey(key="profile_id", device_id=None)
+KEY_STABILIZED = DeviceKey(key="stabilized", device_id=None)
 KEY_TIMESTAMP = DeviceKey(key="timestamp", device_id=None)
 KEY_VOLTAGE = DeviceKey(key="voltage", device_id=None)
 KEY_CHARGING_STATE = DeviceKey(key="charging_state", device_id=None)
@@ -3446,9 +3448,9 @@ def test_Xiaomi_Scale_S400_MJTZC01YM():
                 device_class=DeviceClass.MASS,
                 native_unit_of_measurement=Units.MASS_KILOGRAMS,
             ),
-            KEY_IMPEDANCE: SensorDescription(
-                device_key=KEY_IMPEDANCE,
-                device_class=DeviceClass.IMPEDANCE,
+            KEY_IMPEDANCE_LOW: SensorDescription(
+                device_key=KEY_IMPEDANCE_LOW,
+                device_class=ExtendedSensorDeviceClass.IMPEDANCE_LOW,
                 native_unit_of_measurement=Units.OHM,
             ),
             KEY_HEART_RATE: SensorDescription(
@@ -3473,9 +3475,9 @@ def test_Xiaomi_Scale_S400_MJTZC01YM():
                 device_key=KEY_MASS,
                 native_value=69.9,
             ),
-            KEY_IMPEDANCE: SensorValue(
-                name="Impedance",
-                device_key=KEY_IMPEDANCE,
+            KEY_IMPEDANCE_LOW: SensorValue(
+                name="Impedance Low",
+                device_key=KEY_IMPEDANCE_LOW,
                 native_value=543.2,
             ),
             KEY_HEART_RATE: SensorValue(
@@ -3492,8 +3494,19 @@ def test_Xiaomi_Scale_S400_MJTZC01YM():
                 name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
             ),
         },
-        binary_entity_descriptions={},
-        binary_entity_values={},
+        binary_entity_descriptions={
+            KEY_STABILIZED: BinarySensorDescription(
+                device_key=KEY_STABILIZED,
+                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            ),
+        },
+        binary_entity_values={
+            KEY_STABILIZED: BinarySensorValue(
+                name="Stabilized",
+                device_key=KEY_STABILIZED,
+                native_value=False,
+            ),
+        },
     )
 
 
@@ -3521,9 +3534,9 @@ def test_Xiaomi_Scale_S400_MJTZC01YM_packet_2():
             )
         },
         entity_descriptions={
-            KEY_IMPEDANCE_LOW: SensorDescription(
-                device_key=KEY_IMPEDANCE_LOW,
-                device_class=ExtendedSensorDeviceClass.IMPEDANCE_LOW,
+            KEY_IMPEDANCE_HIGH: SensorDescription(
+                device_key=KEY_IMPEDANCE_HIGH,
+                device_class=ExtendedSensorDeviceClass.IMPEDANCE_HIGH,
                 native_unit_of_measurement=Units.OHM,
             ),
             KEY_PROFILE_ID: SensorDescription(
@@ -3538,9 +3551,9 @@ def test_Xiaomi_Scale_S400_MJTZC01YM_packet_2():
             ),
         },
         entity_values={
-            KEY_IMPEDANCE_LOW: SensorValue(
-                name="Impedance Low",
-                device_key=KEY_IMPEDANCE_LOW,
+            KEY_IMPEDANCE_HIGH: SensorValue(
+                name="Impedance High",
+                device_key=KEY_IMPEDANCE_HIGH,
                 native_value=497.6,
             ),
             KEY_PROFILE_ID: SensorValue(
@@ -3552,8 +3565,19 @@ def test_Xiaomi_Scale_S400_MJTZC01YM_packet_2():
                 name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
             ),
         },
-        binary_entity_descriptions={},
-        binary_entity_values={},
+        binary_entity_descriptions={
+            KEY_STABILIZED: BinarySensorDescription(
+                device_key=KEY_STABILIZED,
+                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            ),
+        },
+        binary_entity_values={
+            KEY_STABILIZED: BinarySensorValue(
+                name="Stabilized",
+                device_key=KEY_STABILIZED,
+                native_value=True,
+            ),
+        },
     )
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3512,7 +3512,7 @@ def test_Xiaomi_Scale_S400_MJTZC01YM():
 
 def test_Xiaomi_Scale_S400_MJTZC01YM_packet_2():
     """Test Xiaomi parser for Xiaomi Body Composition Scale S400 MJTZC01YM
-    (second packet with only low frequency impedance).
+    (second packet with only high frequency impedance).
     """
     data_string = b"HY\xd5;\x0b\xd6\xef\x0b%\xdbrx^~/F\xd6\x00\x00\x00\xd8d-\xf6"
     advertisement = bytes_to_service_info(data_string, address="8C:D0:B2:F6:BE:EF")
@@ -3619,6 +3619,126 @@ def test_Xiaomi_XMWS01XS_press():
                 name="Button Left",
                 event_type="press",
                 event_properties=None,
+            ),
+        },
+    )
+
+
+def test_Xiaomi_Scale_S400_MJTZC01YM_socks():
+    """Test Xiaomi parser for S400 — measurement with socks (no impedance)."""
+    data_string = (
+        b"HY\xd5;\x71\x53\x04\x38\xb5\x89\x4b"
+        b"\x24\x2c\x20\x99\x08\xda\x00\x00\x00\x47\x9e\xcd\xa3"
+    )
+    advertisement = bytes_to_service_info(data_string, address="04:AE:47:67:C6:7C")
+    bindkey = "02d2900363ef629c736a4549677acbee"
+
+    device = XiaomiBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
+    assert device.supported(advertisement)
+    assert device.bindkey_verified
+    assert device.update(advertisement) == SensorUpdate(
+        title="Body Composition Scale C67C (MJTZC01YM)",
+        devices={
+            None: SensorDeviceInfo(
+                name="Body Composition Scale C67C",
+                manufacturer="Xiaomi",
+                model="MJTZC01YM",
+                hw_version=None,
+                sw_version="Xiaomi (MiBeacon V5 encrypted)",
+            )
+        },
+        entity_descriptions={
+            KEY_MASS: SensorDescription(
+                device_key=KEY_MASS,
+                device_class=DeviceClass.MASS,
+                native_unit_of_measurement=Units.MASS_KILOGRAMS,
+            ),
+            KEY_PROFILE_ID: SensorDescription(
+                device_key=KEY_PROFILE_ID,
+                device_class=ExtendedSensorDeviceClass.PROFILE_ID,
+                native_unit_of_measurement=None,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement="dBm",
+            ),
+        },
+        entity_values={
+            KEY_MASS: SensorValue(name="Mass", device_key=KEY_MASS, native_value=74.7),
+            KEY_PROFILE_ID: SensorValue(
+                name="Profile ID", device_key=KEY_PROFILE_ID, native_value=1
+            ),
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
+            ),
+        },
+        binary_entity_descriptions={
+            KEY_STABILIZED: BinarySensorDescription(
+                device_key=KEY_STABILIZED,
+                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            ),
+        },
+        binary_entity_values={
+            KEY_STABILIZED: BinarySensorValue(
+                name="Stabilized", device_key=KEY_STABILIZED, native_value=True
+            ),
+        },
+    )
+
+
+def test_Xiaomi_Scale_S400_MJTZC01YM_reset():
+    """Test Xiaomi parser for S400 — person stepped off scale."""
+    data_string = (
+        b"HY\xd5;\x72\x03\x6c\x67\x94\x35\x5a"
+        b"\x19\xdb\xc8\x64\xbf\xb3\x00\x00\x00\xe4\x15\x1d\xc8"
+    )
+    advertisement = bytes_to_service_info(data_string, address="04:AE:47:67:C6:7C")
+    bindkey = "02d2900363ef629c736a4549677acbee"
+
+    device = XiaomiBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
+    assert device.supported(advertisement)
+    assert device.bindkey_verified
+    assert device.update(advertisement) == SensorUpdate(
+        title="Body Composition Scale C67C (MJTZC01YM)",
+        devices={
+            None: SensorDeviceInfo(
+                name="Body Composition Scale C67C",
+                manufacturer="Xiaomi",
+                model="MJTZC01YM",
+                hw_version=None,
+                sw_version="Xiaomi (MiBeacon V5 encrypted)",
+            )
+        },
+        entity_descriptions={
+            KEY_PROFILE_ID: SensorDescription(
+                device_key=KEY_PROFILE_ID,
+                device_class=ExtendedSensorDeviceClass.PROFILE_ID,
+                native_unit_of_measurement=None,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement="dBm",
+            ),
+        },
+        entity_values={
+            KEY_PROFILE_ID: SensorValue(
+                name="Profile ID", device_key=KEY_PROFILE_ID, native_value=1
+            ),
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
+            ),
+        },
+        binary_entity_descriptions={
+            KEY_STABILIZED: BinarySensorDescription(
+                device_key=KEY_STABILIZED,
+                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            ),
+        },
+        binary_entity_values={
+            KEY_STABILIZED: BinarySensorValue(
+                name="Stabilized", device_key=KEY_STABILIZED, native_value=False
             ),
         },
     )


### PR DESCRIPTION
## Changes

The S400 sends two BLE packets per measurement cycle:
- **Packet 1** — weight + heart rate + impedance_low (50 kHz, larger value)
- **Packet 2** — impedance_high only (250 kHz, smaller value) → end of cycle

### What's new

- Added `IMPEDANCE_HIGH` to `ExtendedSensorDeviceClass`
- Fixed `obj6e16`: impedance routing was inverted — packet with weight now maps
  to `impedance_low`, packet without weight maps to `impedance_high`
- Added `STABILIZED` binary sensor to `ExtendedBinarySensorDeviceClass`:
  - `True` when measurement cycle is complete (impedance_high received, or weight
    only for users with socks)
  - `False` during measurement or when person steps off the scale
- Updated tests accordingly