### PR TITLE
fix: reset S400 stabilized on idle packet and add stabilized support for Scale v1/v2

### DIFF
--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -390,3 +390,9 @@ SLEEPY_DEVICE_MODELS = {
     "M2456B1",
     "M2457B1",
 }
+
+
+S400_MODELS = {
+    "MJTZC01YM",
+    "MJTZC03YM",
+}

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1802,6 +1802,9 @@ def obj6e16(
     heart_rate = (data >> 11) & 0x7F
     impedance = data >> 18
 
+    if not hasattr(device, "_s400_stabilized_lock"):
+        device._s400_stabilized_lock = False
+
     device.update_sensor(
         key=ExtendedSensorDeviceClass.PROFILE_ID,
         name="Profile ID",
@@ -1810,8 +1813,9 @@ def obj6e16(
         native_value=profile_id,
     )
 
+    # Reset stabilization state when scale is empty / user steps off
     if mass == 0 and heart_rate == 0 and impedance == 0:
-        # Person stepped off the scale → reset
+        device._s400_stabilized_lock = False
         device.update_binary_sensor(
             key=ExtendedBinarySensorDeviceClass.STABILIZED,
             name="Stabilized",
@@ -1840,6 +1844,7 @@ def obj6e16(
             native_unit_of_measurement=Units.OHM,
             native_value=impedance / 10,
         )
+        device._s400_stabilized_lock = True
         device.update_binary_sensor(
             key=ExtendedBinarySensorDeviceClass.STABILIZED,
             name="Stabilized",
@@ -1848,21 +1853,23 @@ def obj6e16(
         )
     elif impedance != 0:
         # Packet with weight → low frequency 50 kHz → impedance_low
-        device.update_sensor(
-            key=ExtendedSensorDeviceClass.IMPEDANCE_LOW,
-            name="Impedance Low",
-            device_class=ExtendedSensorDeviceClass.IMPEDANCE_LOW,
-            native_unit_of_measurement=Units.OHM,
-            native_value=impedance / 10,
-        )
-        device.update_binary_sensor(
-            key=ExtendedBinarySensorDeviceClass.STABILIZED,
-            name="Stabilized",
-            device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
-            native_value=False,
-        )
+        if not device._s400_stabilized_lock:
+            device.update_sensor(
+                key=ExtendedSensorDeviceClass.IMPEDANCE_LOW,
+                name="Impedance Low",
+                device_class=ExtendedSensorDeviceClass.IMPEDANCE_LOW,
+                native_unit_of_measurement=Units.OHM,
+                native_value=impedance / 10,
+            )
+            device.update_binary_sensor(
+                key=ExtendedBinarySensorDeviceClass.STABILIZED,
+                name="Stabilized",
+                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+                native_value=False,
+            )
     else:
         # Packet with weight only → with socks → stabilized
+        device._s400_stabilized_lock = True
         device.update_binary_sensor(
             key=ExtendedBinarySensorDeviceClass.STABILIZED,
             name="Stabilized",

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -2303,6 +2303,15 @@ class XiaomiBluetoothDeviceData(BluetoothData):
         mass_stabilized = bool(int(control_byte & (1 << 5)))
         mass_removed = bool(int(control_byte & (1 << 7)))
 
+        # Reset stabilization state when scale is empty / user steps off
+        if mass == 0:
+            self.update_binary_sensor(
+                key=ExtendedBinarySensorDeviceClass.STABILIZED,
+                name="Stabilized",
+                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+                native_value=False,
+            )
+
         if mass_in_kilograms:
             # sensor advertises kg * 200
             mass /= 200
@@ -2316,8 +2325,25 @@ class XiaomiBluetoothDeviceData(BluetoothData):
         self.update_predefined_sensor(
             SensorLibrary.MASS_NON_STABILIZED__MASS_KILOGRAMS, mass
         )
-        if mass_stabilized and not mass_removed:
+        
+        # Handling stabilization sensor based on weight status
+        if mass_stabilized and not mass_removed and mass > 0:
             self.update_predefined_sensor(SensorLibrary.MASS__MASS_KILOGRAMS, mass)
+            self.update_binary_sensor(
+                key=ExtendedBinarySensorDeviceClass.STABILIZED,
+                name="Stabilized",
+                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+                native_value=True,
+            )
+        else:
+            # Scale is measuring / not stabilized yet
+            if mass > 0:
+                self.update_binary_sensor(
+                    key=ExtendedBinarySensorDeviceClass.STABILIZED,
+                    name="Stabilized",
+                    device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+                    native_value=False,
+                )
 
         return True
 
@@ -2352,6 +2378,15 @@ class XiaomiBluetoothDeviceData(BluetoothData):
         mass_removed = bool(int(control_flags[8]))
         impedance_stabilized = bool(int(control_flags[14]))
 
+        # Reset stabilization state when scale is empty / user steps off
+        if mass == 0:
+            self.update_binary_sensor(
+                key=ExtendedBinarySensorDeviceClass.STABILIZED,
+                name="Stabilized",
+                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+                native_value=False,
+            )
+
         if mass_in_kilograms:
             # sensor advertises kg * 200
             mass /= 200
@@ -2365,10 +2400,28 @@ class XiaomiBluetoothDeviceData(BluetoothData):
         self.update_predefined_sensor(
             SensorLibrary.MASS_NON_STABILIZED__MASS_KILOGRAMS, mass
         )
-        if mass_stabilized and not mass_removed:
+        
+        # Handling stabilization sensor based on weight status
+        if mass_stabilized and not mass_removed and mass > 0:
             self.update_predefined_sensor(SensorLibrary.MASS__MASS_KILOGRAMS, mass)
             if impedance_stabilized:
                 self.update_predefined_sensor(SensorLibrary.IMPEDANCE__OHM, impedance)
+            
+            self.update_binary_sensor(
+                key=ExtendedBinarySensorDeviceClass.STABILIZED,
+                name="Stabilized",
+                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+                native_value=True,
+            )
+        else:
+            # Scale is measuring / not stabilized yet
+            if mass > 0:
+                self.update_binary_sensor(
+                    key=ExtendedBinarySensorDeviceClass.STABILIZED,
+                    name="Stabilized",
+                    device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+                    native_value=False,
+                )
 
         return True
 

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1802,8 +1802,6 @@ def obj6e16(
     heart_rate = (data >> 11) & 0x7F
     impedance = data >> 18
 
-    _LOGGER.debug("S400 obj6e16: profile=%s mass=%s heart_rate=%s impedance=%s", profile_id, mass, heart_rate, impedance)
-
     device.update_sensor(
         key=ExtendedSensorDeviceClass.PROFILE_ID,
         name="Profile ID",
@@ -2204,6 +2202,14 @@ class XiaomiBluetoothDeviceData(BluetoothData):
         if frctrl_object_include == 0:
             # data does not contain Object
             _LOGGER.debug("Advertisement doesn't contain payload, adv: %s", data.hex())
+            # S400 idle packet — reset stabilized
+            if device_type in self._S400_MODELS:
+                self.update_binary_sensor(
+                    key=ExtendedBinarySensorDeviceClass.STABILIZED,
+                    name="Stabilized",
+                    device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+                    native_value=False,
+                )
             return False
 
         self.pending = False
@@ -2288,14 +2294,13 @@ class XiaomiBluetoothDeviceData(BluetoothData):
             return False
 
         uuid16 = (data[3] << 8) | data[2]
+
         identifier = short_address(service_info.address)
 
         self.device_id = uuid16
-        # Don't overwrite device identity if already identified as S400
-        if self.device_type not in self._S400_MODELS:
-            self.set_title(f"Mi Smart Scale ({identifier})")
-            self.set_device_name(f"Mi Smart Scale ({identifier})")
-            self.set_device_type("XMTZC01HM/XMTZC04HM")
+        self.set_title(f"Mi Smart Scale ({identifier})")
+        self.set_device_name(f"Mi Smart Scale ({identifier})")
+        self.set_device_type("XMTZC01HM/XMTZC04HM")
         self.set_device_manufacturer("Xiaomi")
         self.pending = False
         self.sleepy_device = True
@@ -2309,7 +2314,7 @@ class XiaomiBluetoothDeviceData(BluetoothData):
         mass_stabilized = bool(int(control_byte & (1 << 5)))
         mass_removed = bool(int(control_byte & (1 << 7)))
 
-        # Reset stabilized for all scales including S400
+        # Reset stabilization state when scale is empty / user steps off
         if mass == 0:
             self.update_binary_sensor(
                 key=ExtendedBinarySensorDeviceClass.STABILIZED,

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -39,7 +39,7 @@ from .const import (
     ExtendedBinarySensorDeviceClass,
     ExtendedSensorDeviceClass,
 )
-from .devices import DEVICE_TYPES, SLEEPY_DEVICE_MODELS
+from .devices import DEVICE_TYPES, SLEEPY_DEVICE_MODELS, S400_MODELS
 from .events import EventDeviceKeys
 from .locks import BLE_LOCK_ACTION, BLE_LOCK_ERROR, BLE_LOCK_METHOD
 
@@ -2203,7 +2203,7 @@ class XiaomiBluetoothDeviceData(BluetoothData):
             # data does not contain Object
             _LOGGER.debug("Advertisement doesn't contain payload, adv: %s", data.hex())
             # S400 idle packet — reset stabilized
-            if device_type in self._S400_MODELS:
+            if device_type in S400_MODELS:
                 self.update_binary_sensor(
                     key=ExtendedBinarySensorDeviceClass.STABILIZED,
                     name="Stabilized",
@@ -2286,8 +2286,6 @@ class XiaomiBluetoothDeviceData(BluetoothData):
 
         return True
 
-    # S400 models — share SERVICE_SCALE1 UUID for idle packets
-    _S400_MODELS = {"MJTZC01YM", "MJTZC03YM"}
 
     def _parse_scale_v1(self, service_info: BluetoothServiceInfo, data: bytes) -> bool:
         if len(data) != 10:

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -2336,7 +2336,7 @@ class XiaomiBluetoothDeviceData(BluetoothData):
         self.update_predefined_sensor(
             SensorLibrary.MASS_NON_STABILIZED__MASS_KILOGRAMS, mass
         )
-        
+
         # Handling stabilization sensor based on weight status
         if mass_stabilized and not mass_removed and mass > 0:
             self.update_predefined_sensor(SensorLibrary.MASS__MASS_KILOGRAMS, mass)
@@ -2411,13 +2411,13 @@ class XiaomiBluetoothDeviceData(BluetoothData):
         self.update_predefined_sensor(
             SensorLibrary.MASS_NON_STABILIZED__MASS_KILOGRAMS, mass
         )
-        
+
         # Handling stabilization sensor based on weight status
         if mass_stabilized and not mass_removed and mass > 0:
             self.update_predefined_sensor(SensorLibrary.MASS__MASS_KILOGRAMS, mass)
             if impedance_stabilized:
                 self.update_predefined_sensor(SensorLibrary.IMPEDANCE__OHM, impedance)
-            
+
             self.update_binary_sensor(
                 key=ExtendedBinarySensorDeviceClass.STABILIZED,
                 name="Stabilized",

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -39,7 +39,7 @@ from .const import (
     ExtendedBinarySensorDeviceClass,
     ExtendedSensorDeviceClass,
 )
-from .devices import DEVICE_TYPES, SLEEPY_DEVICE_MODELS, S400_MODELS
+from .devices import DEVICE_TYPES, S400_MODELS, SLEEPY_DEVICE_MODELS
 from .events import EventDeviceKeys
 from .locks import BLE_LOCK_ACTION, BLE_LOCK_ERROR, BLE_LOCK_METHOD
 
@@ -2290,7 +2290,6 @@ class XiaomiBluetoothDeviceData(BluetoothData):
                 payload_start = next_start
 
         return True
-
 
     def _parse_scale_v1(self, service_info: BluetoothServiceInfo, data: bytes) -> bool:
         if len(data) != 10:

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1802,6 +1802,8 @@ def obj6e16(
     heart_rate = (data >> 11) & 0x7F
     impedance = data >> 18
 
+    _LOGGER.debug("S400 obj6e16: profile=%s mass=%s heart_rate=%s impedance=%s", profile_id, mass, heart_rate, impedance)
+
     device.update_sensor(
         key=ExtendedSensorDeviceClass.PROFILE_ID,
         name="Profile ID",

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1802,9 +1802,6 @@ def obj6e16(
     heart_rate = (data >> 11) & 0x7F
     impedance = data >> 18
 
-    if not hasattr(device, "_s400_stabilized_lock"):
-        device._s400_stabilized_lock = False
-
     device.update_sensor(
         key=ExtendedSensorDeviceClass.PROFILE_ID,
         name="Profile ID",
@@ -1813,9 +1810,8 @@ def obj6e16(
         native_value=profile_id,
     )
 
-    # Reset stabilization state when scale is empty / user steps off
     if mass == 0 and heart_rate == 0 and impedance == 0:
-        device._s400_stabilized_lock = False
+        # Person stepped off the scale → reset
         device.update_binary_sensor(
             key=ExtendedBinarySensorDeviceClass.STABILIZED,
             name="Stabilized",
@@ -1844,7 +1840,6 @@ def obj6e16(
             native_unit_of_measurement=Units.OHM,
             native_value=impedance / 10,
         )
-        device._s400_stabilized_lock = True
         device.update_binary_sensor(
             key=ExtendedBinarySensorDeviceClass.STABILIZED,
             name="Stabilized",
@@ -1853,23 +1848,21 @@ def obj6e16(
         )
     elif impedance != 0:
         # Packet with weight → low frequency 50 kHz → impedance_low
-        if not device._s400_stabilized_lock:
-            device.update_sensor(
-                key=ExtendedSensorDeviceClass.IMPEDANCE_LOW,
-                name="Impedance Low",
-                device_class=ExtendedSensorDeviceClass.IMPEDANCE_LOW,
-                native_unit_of_measurement=Units.OHM,
-                native_value=impedance / 10,
-            )
-            device.update_binary_sensor(
-                key=ExtendedBinarySensorDeviceClass.STABILIZED,
-                name="Stabilized",
-                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
-                native_value=False,
-            )
+        device.update_sensor(
+            key=ExtendedSensorDeviceClass.IMPEDANCE_LOW,
+            name="Impedance Low",
+            device_class=ExtendedSensorDeviceClass.IMPEDANCE_LOW,
+            native_unit_of_measurement=Units.OHM,
+            native_value=impedance / 10,
+        )
+        device.update_binary_sensor(
+            key=ExtendedBinarySensorDeviceClass.STABILIZED,
+            name="Stabilized",
+            device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            native_value=False,
+        )
     else:
         # Packet with weight only → with socks → stabilized
-        device._s400_stabilized_lock = True
         device.update_binary_sensor(
             key=ExtendedBinarySensorDeviceClass.STABILIZED,
             name="Stabilized",
@@ -2285,18 +2278,22 @@ class XiaomiBluetoothDeviceData(BluetoothData):
 
         return True
 
+    # S400 models — share SERVICE_SCALE1 UUID for idle packets
+    _S400_MODELS = {"MJTZC01YM", "MJTZC03YM"}
+
     def _parse_scale_v1(self, service_info: BluetoothServiceInfo, data: bytes) -> bool:
         if len(data) != 10:
             return False
 
         uuid16 = (data[3] << 8) | data[2]
-
         identifier = short_address(service_info.address)
 
         self.device_id = uuid16
-        self.set_title(f"Mi Smart Scale ({identifier})")
-        self.set_device_name(f"Mi Smart Scale ({identifier})")
-        self.set_device_type("XMTZC01HM/XMTZC04HM")
+        # Don't overwrite device identity if already identified as S400
+        if self.device_type not in self._S400_MODELS:
+            self.set_title(f"Mi Smart Scale ({identifier})")
+            self.set_device_name(f"Mi Smart Scale ({identifier})")
+            self.set_device_type("XMTZC01HM/XMTZC04HM")
         self.set_device_manufacturer("Xiaomi")
         self.pending = False
         self.sleepy_device = True
@@ -2310,7 +2307,7 @@ class XiaomiBluetoothDeviceData(BluetoothData):
         mass_stabilized = bool(int(control_byte & (1 << 5)))
         mass_removed = bool(int(control_byte & (1 << 7)))
 
-        # Reset stabilization state when scale is empty / user steps off
+        # Reset stabilized for all scales including S400
         if mass == 0:
             self.update_binary_sensor(
                 key=ExtendedBinarySensorDeviceClass.STABILIZED,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1584,7 +1584,10 @@ def test_Xiaomi_Scale1_reset():
 
 
 def test_Xiaomi_Scale2_reset():
-    """Test Xiaomi parser for Mi Body Composition Scale (MiScale V2) — person stepped off scale."""
+    """Test Xiaomi parser for Mi Body Composition Scale (MiScale V2).
+
+    Person stepped off scale.
+    """
     # control_bytes: mass_removed=True, mass_stabilized=False, mass=0
     data_string = b"\x02\x82\xb2\x07\x05\x04\x0f\x02\x01\x00\x00\x00\x00"
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1520,8 +1520,6 @@ def test_Xiaomi_Scale2_non_stabilized():
     )
 
 
-
-
 def test_Xiaomi_Scale1_reset():
     """Test Xiaomi parser for Mi Smart Scale (MiScale V1) — person stepped off scale."""
     # control_byte=0x80 (mass_removed=True), mass=0
@@ -1646,6 +1644,7 @@ def test_Xiaomi_Scale2_reset():
             ),
         },
     )
+
 
 def test_Xiaomi_GCLS002():
     """Test Xiaomi parser for GCLS002 / HHCCJCY09."""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1240,6 +1240,17 @@ def test_Xiaomi_Scale1():
                 name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
             ),
         },
+        binary_entity_descriptions={
+            KEY_STABILIZED: BinarySensorDescription(
+                device_key=KEY_STABILIZED,
+                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            ),
+        },
+        binary_entity_values={
+            KEY_STABILIZED: BinarySensorValue(
+                name="Stabilized", device_key=KEY_STABILIZED, native_value=True
+            ),
+        },
     )
 
 
@@ -1291,6 +1302,17 @@ def test_Xiaomi_Scale1_mass_removed():
                 name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
             ),
         },
+        binary_entity_descriptions={
+            KEY_STABILIZED: BinarySensorDescription(
+                device_key=KEY_STABILIZED,
+                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            ),
+        },
+        binary_entity_values={
+            KEY_STABILIZED: BinarySensorValue(
+                name="Stabilized", device_key=KEY_STABILIZED, native_value=False
+            ),
+        },
     )
 
 
@@ -1340,6 +1362,17 @@ def test_Xiaomi_Scale1_non_stabilized():
             ),
             KEY_SIGNAL_STRENGTH: SensorValue(
                 name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
+            ),
+        },
+        binary_entity_descriptions={
+            KEY_STABILIZED: BinarySensorDescription(
+                device_key=KEY_STABILIZED,
+                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            ),
+        },
+        binary_entity_values={
+            KEY_STABILIZED: BinarySensorValue(
+                name="Stabilized", device_key=KEY_STABILIZED, native_value=False
             ),
         },
     )
@@ -1411,6 +1444,17 @@ def test_Xiaomi_Scale2():
                 name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
             ),
         },
+        binary_entity_descriptions={
+            KEY_STABILIZED: BinarySensorDescription(
+                device_key=KEY_STABILIZED,
+                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            ),
+        },
+        binary_entity_values={
+            KEY_STABILIZED: BinarySensorValue(
+                name="Stabilized", device_key=KEY_STABILIZED, native_value=True
+            ),
+        },
     )
 
 
@@ -1460,6 +1504,17 @@ def test_Xiaomi_Scale2_non_stabilized():
             ),
             KEY_SIGNAL_STRENGTH: SensorValue(
                 name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
+            ),
+        },
+        binary_entity_descriptions={
+            KEY_STABILIZED: BinarySensorDescription(
+                device_key=KEY_STABILIZED,
+                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            ),
+        },
+        binary_entity_values={
+            KEY_STABILIZED: BinarySensorValue(
+                name="Stabilized", device_key=KEY_STABILIZED, native_value=False
             ),
         },
     )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1520,6 +1520,133 @@ def test_Xiaomi_Scale2_non_stabilized():
     )
 
 
+
+
+def test_Xiaomi_Scale1_reset():
+    """Test Xiaomi parser for Mi Smart Scale (MiScale V1) — person stepped off scale."""
+    # control_byte=0x80 (mass_removed=True), mass=0
+    data_string = b"\x80\x00\x00\xe5\x07\x04\x0b\x10\x13\x01"
+
+    device = XiaomiBluetoothDeviceData()
+    assert device.update(
+        BluetoothServiceInfo(
+            name="MISCA",
+            address="50:FB:19:1B:B5:DC",
+            rssi=-60,
+            manufacturer_data={},
+            service_data={SERVICE_SCALE1: data_string},
+            service_uuids=[SERVICE_SCALE1],
+            source="",
+        )
+    ) == SensorUpdate(
+        title="Mi Smart Scale (B5DC)",
+        devices={
+            None: SensorDeviceInfo(
+                name="Mi Smart Scale (B5DC)",
+                manufacturer="Xiaomi",
+                model="XMTZC01HM/XMTZC04HM",
+                hw_version=None,
+                sw_version=None,
+            )
+        },
+        entity_descriptions={
+            KEY_MASS_NON_STABILIZED: SensorDescription(
+                device_key=KEY_MASS_NON_STABILIZED,
+                device_class=DeviceClass.MASS_NON_STABILIZED,
+                native_unit_of_measurement=Units.MASS_KILOGRAMS,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
+            KEY_MASS_NON_STABILIZED: SensorValue(
+                name="Mass Non Stabilized",
+                device_key=KEY_MASS_NON_STABILIZED,
+                native_value=0.0,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
+            ),
+        },
+        binary_entity_descriptions={
+            KEY_STABILIZED: BinarySensorDescription(
+                device_key=KEY_STABILIZED,
+                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            ),
+        },
+        binary_entity_values={
+            KEY_STABILIZED: BinarySensorValue(
+                name="Stabilized", device_key=KEY_STABILIZED, native_value=False
+            ),
+        },
+    )
+
+
+def test_Xiaomi_Scale2_reset():
+    """Test Xiaomi parser for Mi Body Composition Scale (MiScale V2) — person stepped off scale."""
+    # control_bytes: mass_removed=True, mass_stabilized=False, mass=0
+    data_string = b"\x02\x82\xb2\x07\x05\x04\x0f\x02\x01\x00\x00\x00\x00"
+
+    device = XiaomiBluetoothDeviceData()
+    assert device.update(
+        BluetoothServiceInfo(
+            name="MIBFS",
+            address="50:FB:19:1B:B5:DC",
+            rssi=-60,
+            manufacturer_data={},
+            service_data={SERVICE_SCALE2: data_string},
+            service_uuids=[SERVICE_SCALE2],
+            source="",
+        )
+    ) == SensorUpdate(
+        title="Mi Body Composition Scale (B5DC)",
+        devices={
+            None: SensorDeviceInfo(
+                name="Mi Body Composition Scale (B5DC)",
+                manufacturer="Xiaomi",
+                model="XMTZC02HM/XMTZC05HM/NUN4049CN",
+                hw_version=None,
+                sw_version=None,
+            )
+        },
+        entity_descriptions={
+            KEY_MASS_NON_STABILIZED: SensorDescription(
+                device_key=KEY_MASS_NON_STABILIZED,
+                device_class=DeviceClass.MASS_NON_STABILIZED,
+                native_unit_of_measurement=Units.MASS_KILOGRAMS,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
+            KEY_MASS_NON_STABILIZED: SensorValue(
+                name="Mass Non Stabilized",
+                device_key=KEY_MASS_NON_STABILIZED,
+                native_value=0.0,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
+            ),
+        },
+        binary_entity_descriptions={
+            KEY_STABILIZED: BinarySensorDescription(
+                device_key=KEY_STABILIZED,
+                device_class=ExtendedBinarySensorDeviceClass.STABILIZED,
+            ),
+        },
+        binary_entity_values={
+            KEY_STABILIZED: BinarySensorValue(
+                name="Stabilized", device_key=KEY_STABILIZED, native_value=False
+            ),
+        },
+    )
+
 def test_Xiaomi_GCLS002():
     """Test Xiaomi parser for GCLS002 / HHCCJCY09."""
     data_string = b"q \xbc\x03\xcd>Ym\x8d|\xc4\r\x04\x10\x02<\x01"


### PR DESCRIPTION
### Summary

Follow-up to the merged PR adding `stabilized` binary sensor for S400. This PR fixes a bug where the S400 stabilized sensor was not reset when the user stepped off the scale, and extends `stabilized` support to Mi Smart Scale v1 and Mi Body Composition Scale v2.

### Changes

#### `_parse_xiaomi` — S400 idle packet fix
- Added `_S400_MODELS` class attribute (`MJTZC01YM`, `MJTZC03YM`)
- When an S400 idle packet is received (`frctrl_object_include == 0`), the stabilized sensor is now reset to `OFF` — previously it was silently ignored, leaving the sensor stuck on `ON` after a barefoot weighing

#### `_parse_scale_v1` — Mi Smart Scale (XMTZC01HM/XMTZC04HM)
- Added `stabilized` binary sensor: `ON` when `mass_stabilized=True` and `mass > 0`, `OFF` otherwise
- Reset to `OFF` on `mass == 0` (person stepped off)

#### `_parse_scale_v2` — Mi Body Composition Scale (XMTZC02HM/XMTZC05HM/NUN4049CN)
- Added `stabilized` binary sensor with the same logic as v1
- Impedance is only published when `impedance_stabilized=True`

### Tests added
- `test_Xiaomi_Scale1_reset` — v1 reset when person steps off (mass=0, stabilized=False)
- `test_Xiaomi_Scale2_reset` — v2 reset when person steps off (mass=0, stabilized=False)