### PR TITLE
feat: Add MJWSD05MMC newer HW rev (Temperature/Humidity Sensor 3, product id 0x4C47)

### DIFF
--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -123,6 +123,10 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         name="Temperature/Humidity Sensor",
         model="MJWSD05MMC",
     ),
+    0x4C47: DeviceEntry(
+        name="Temperature/Humidity Sensor",
+        model="MJWSD05MMC",
+    ),
     0x55B5: DeviceEntry(
         name="Temperature/Humidity Sensor",
         model="MJWSD06MMC",


### PR DESCRIPTION
## What

Adds the BLE product ID **`0x4C47` (19527)** to `DEVICE_TYPES`, mapped to the
already-supported `MJWSD05MMC` model.

```python
    0x4C47: DeviceEntry(
        name="Temperature/Humidity Sensor",
        model="MJWSD05MMC",
    ),
```

## Why

`MJWSD05MMC` (Xiaomi *Temperature Humidity Sensor 3*) ships in more than one hardware revision. The library currently maps it only to product ID `0x2832` (decimal 10290 - the older rev). A newer rev (MiOT id `xiaomi.sensor_ht.o3`, firmware `2.0.0_0005`) advertises with product ID **`0x4C47`**, which is absent from `devices.py`. Because `XiaomiBluetoothDeviceData.supported()` looks the product ID up in `DEVICE_TYPES`, the advertisement is treated as unsupported and Home Assistant never offers a discovery flow - even though the device is heard fine and broadcasts standard, already-decoded MiBeacon objects.

This is the same "supported in N hardware versions" pattern as other entries in the file; it only needs the new product ID aliased to the existing model.

## No parser changes needed

The device uses the standard `0x48xx` MiBeacon objects this library already decodes:

- `0x4801` → temperature (float)
- `0x4802` / `0x4808` → humidity
- `0x4803` → battery

A captured encrypted `fe95` frame from a live unit (`A4:C1:38:DA:42:EE`) decrypts cleanly and yields object `0x4801` = float `11.3` (°C):

```text
fe95 service data: 48 59 47 4C 0A 7C 85 CA CD AA E5 6E 08 00 00 CE BD AA 3D
frame control:     0x5948  (encrypted MiBeacon v5)
product id:        bytes [2:4] = 47 4C -> 0x4C47
decrypted object:  0x4801, len 4, data CD CC 34 41 = float 11.3
```

(The sibling `0x4C60` / `XMPIRO2GSXS` in the same product-ID range is already supported, so this range is expected for these devices.)

## Tested

- Verified `0x4C47` is absent from `devices.py` on the `v1.11.0` tag and on  `main`; `0x2832` (MJWSD05MMC) and `0x4C60` (XMPIRO2GSXS) are present.
- Confirmed `parser.py` (`v1.11.0`) decodes `0x4801`/`0x4802`/`0x4803`/`0x4808`.
- Validated end-to-end on a live unit: with the entry added, Home Assistant  discovers the device, accepts its bind key, and reports temperature, humidity and battery over an ESPHome Bluetooth proxy.

