### PR TITLE
fix: mark MS1BB(MI) as sleepy device

### DIFF
--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -382,6 +382,7 @@ SLEEPY_DEVICE_MODELS = {
     "PS1BB",
     "JTYJGD03MI",
     "MCCGQ02HL",
+    "MS1BB(MI)",
     "RTCGQ02LM",
     "MMC-W505",
     "RS1BB(MI)",


### PR DESCRIPTION
## Summary

This PR adds `MS1BB(MI)` to `SLEEPY_DEVICE_MODELS`.

## Device

- Device: Linptech Door/Window Sensor
- Model: `MS1BB(MI)`
- Product ID: `0x1889`
- Home Assistant integration: Xiaomi BLE
- Transport: BLE advertisements via Bluetooth proxy

## Observed behavior

The device is discovered correctly as:

- `Door/Window Sensor`
- model `MS1BB(MI)`

Open/close state changes are decoded correctly and are received immediately when the door/window sensor is opened or closed.

However, after approximately 4–5 minutes without a state change, Home Assistant marks the binary sensor as unavailable. As soon as the sensor is opened or closed again, Home Assistant immediately receives the BLE advertisement and the entity becomes available again with the correct state.

## Expected behavior

This device should be treated as a sleepy BLE device. It appears to stop or greatly reduce advertising while idle to save battery, similar to other battery-powered Xiaomi/Linptech door, motion, and presence sensors already listed in `SLEEPY_DEVICE_MODELS`.

## Why this fix

`MS1BB(MI)` is already defined in `DEVICE_TYPES` as product ID `0x1889`, but it is currently missing from `SLEEPY_DEVICE_MODELS`.

Home Assistant's Xiaomi BLE binary sensor availability keeps entities available when the coordinator identifies the device as sleepy. Without this model in the sleepy list, the entity falls back to normal Bluetooth availability tracking and becomes unavailable when no advertisement is seen for several minutes.

## Testing

Tested with a Linptech `MS1BB(MI)` door/window sensor bound through Xiaomi Home and used locally through Home Assistant Xiaomi BLE.

Observed:

- Opening the sensor updates Home Assistant immediately.
- Closing the sensor updates Home Assistant immediately.
- With no state changes, the entity becomes unavailable after approximately 4–5 minutes.
- Opening or closing the sensor again immediately restores availability and updates the state.

This PR only adds the existing model `MS1BB(MI)` to the sleepy device list.
