### PR TITLE
fix: report door left open for obj4a1a

### DIFF
--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1408,7 +1408,7 @@ def obj4a1a(
         device.update_predefined_binary_sensor(BinarySensorDeviceClass.OPENING, True)
         device.update_binary_sensor(
             key=ExtendedBinarySensorDeviceClass.DOOR_LEFT_OPEN,
-            native_value=False,
+            native_value=True,
             device_class=ExtendedBinarySensorDeviceClass.DOOR_LEFT_OPEN,
             name="Door left open",
         )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3076,6 +3076,59 @@ def test_Xiaomi_MS1BB_MI_obj4a12():
     )
 
 
+def test_Xiaomi_MS1BB_MI_obj4a1a():
+    """Test Xiaomi parser for Linptech MS1BB(MI) with obj4a1a."""
+    data_string = b"PY\x89\x18\x01g\xe5f8\xc1\xa4\x1a\x4a\x01\x01"
+    advertisement = bytes_to_service_info(data_string, address="A4:C1:38:66:E5:67")
+
+    device = XiaomiBluetoothDeviceData()
+    assert device.supported(advertisement)
+    assert device.update(advertisement) == SensorUpdate(
+        title="Door/Window Sensor E567 (MS1BB(MI))",
+        devices={
+            None: SensorDeviceInfo(
+                name="Door/Window Sensor E567",
+                manufacturer="Xiaomi",
+                model="MS1BB(MI)",
+                hw_version=None,
+                sw_version="Xiaomi (MiBeacon V5)",
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement="dBm",
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
+            ),
+        },
+        binary_entity_descriptions={
+            KEY_BINARY_OPENING: BinarySensorDescription(
+                device_key=KEY_BINARY_OPENING,
+                device_class=BinarySensorDeviceClass.OPENING,
+            ),
+            KEY_BINARY_DOOR_LEFT_OPEN: BinarySensorDescription(
+                device_key=KEY_BINARY_DOOR_LEFT_OPEN,
+                device_class=ExtendedBinarySensorDeviceClass.DOOR_LEFT_OPEN,
+            ),
+        },
+        binary_entity_values={
+            KEY_BINARY_OPENING: BinarySensorValue(
+                device_key=KEY_BINARY_OPENING, name="Opening", native_value=True
+            ),
+            KEY_BINARY_DOOR_LEFT_OPEN: BinarySensorValue(
+                device_key=KEY_BINARY_DOOR_LEFT_OPEN,
+                name="Door left open",
+                native_value=True,
+            ),
+        },
+    )
+
+
 def test_Xiaomi_MS1BB_MI_obj4a13():
     """Test Xiaomi parser for Linptech MS1BB(MI) with obj4a13."""
     data_string = b"XY\x89\x18\x91g\xe5f8\xc1\xa4\xd6\x12\rm&\x00\x00o\xbc\x0c\xb4"


### PR DESCRIPTION
## Summary

This PR fixes `obj4a1a()` so the `Door left open` binary sensor is set to `true` when the device reports a door-left-open event.

## Problem

`obj4a1a()` is documented as `Door left open`, and it already updates:

- `BinarySensorDeviceClass.OPENING` to `true`
- `ExtendedBinarySensorDeviceClass.DOOR_LEFT_OPEN`

However, the current implementation sets `Door left open` to `native_value=False`, so Home Assistant displays the diagnostic entity as OK even when the device reports the door-left-open condition.

## Fix

Change the `Door left open` update in `obj4a1a()` from:

```python
native_value=False
```

to:

```python
native_value=True
```

## Device Tested

- Device: Linptech Door/Window Sensor
- Model: `MS1BB(MI)`
- Product ID: `0x1889`
- Home Assistant integration: Xiaomi BLE
- Transport: BLE advertisements via Bluetooth proxy

## Observed Behavior Before Fix

The device was discovered correctly and open/close state updates worked.

When the door was left open long enough for the device to report the long-open condition, Home Assistant still showed:

- `Opening`: Open
- `Door left open`: OK

So the long-open diagnostic was present, but its state was inverted/wrong.

## Observed Behavior After Fix

With the same device and bindkey, after applying this parser change locally through a custom `xiaomi-ble` package:

- `Opening` stayed Open
- `Door left open` changed from OK to Problem
- Home Assistant activity showed `Door left open detected problem`

This confirms the advertisement is being received and parsed, but the previous `native_value=False` prevented Home Assistant from representing the problem state correctly.

## Related PR

This is separate from #338, which marks `MS1BB(MI)` as a sleepy BLE device to avoid unavailable state while idle.

That availability fix and this parser fix address different symptoms:

- #338: idle availability handling
- this PR: correct `Door left open` state value

## Testing

- Added/updated parser regression coverage for `obj4a1a()`
- Verified locally with a Linptech `MS1BB(MI)` door/window sensor in Home Assistant Core 2026.7.1
