### PR TITLE
feat: add Xiaomi SJWS02LM support

### DIFF
--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -208,6 +208,10 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         name="Flood Detector",
         model="SJWS01LM",
     ),
+    0x6375: DeviceEntry(
+        name="Water Leak Sensor 2",
+        model="SJWS02LM",
+    ),
     0x045C: DeviceEntry(
         name="Smart Kettle",
         model="V-SK152",
@@ -386,6 +390,7 @@ SLEEPY_DEVICE_MODELS = {
     "RTCGQ02LM",
     "MMC-W505",
     "RS1BB(MI)",
+    "SJWS02LM",
     "XMOSB01XS",
     "MJTZC01YM",
     "MJTZC03YM",

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -1097,9 +1097,33 @@ def obj4806(
     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
 ) -> dict[str, Any]:
     """Moisture"""
+    if len(xobj) != 1:
+        return {}
+    if device_type == "SJWS02LM":
+        device.update_predefined_binary_sensor(
+            BinarySensorDeviceClass.MOISTURE,
+            xobj[0] > 0,
+            key="bottom_submersion",
+            name="Bottom submersion",
+        )
+        return {}
     device.update_predefined_binary_sensor(
         BinarySensorDeviceClass.MOISTURE, xobj[0] > 0
     )
+    return {}
+
+
+def obj487b(
+    xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
+) -> dict[str, Any]:
+    """Top splash sensor state for Xiaomi Water Leak Sensor 2."""
+    if len(xobj) == 1 and device_type == "SJWS02LM":
+        device.update_predefined_binary_sensor(
+            BinarySensorDeviceClass.MOISTURE,
+            xobj[0] > 0,
+            key="top_splash",
+            name="Top splash",
+        )
     return {}
 
 
@@ -1411,6 +1435,36 @@ def obj4a1a(
             native_value=True,
             device_class=ExtendedBinarySensorDeviceClass.DOOR_LEFT_OPEN,
             name="Door left open",
+        )
+    return {}
+
+
+def obj4a68(
+    xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
+) -> dict[str, Any]:
+    """Water alarm/clear event for Xiaomi Water Leak Sensor 2.
+
+    The device does not always include its persistent 0x4806/0x487B state in
+    the same advertisement, so these transition events also reconcile the two
+    binary sensor values.
+    """
+    if len(xobj) != 1 or device_type != "SJWS02LM":
+        return {}
+
+    event_type = xobj[0]
+    if event_type in (0, 1):
+        device.update_predefined_binary_sensor(
+            BinarySensorDeviceClass.MOISTURE,
+            event_type == 0,
+            key="bottom_submersion",
+            name="Bottom submersion",
+        )
+    elif event_type in (2, 3):
+        device.update_predefined_binary_sensor(
+            BinarySensorDeviceClass.MOISTURE,
+            event_type == 2,
+            key="top_splash",
+            name="Top splash",
         )
     return {}
 
@@ -1934,6 +1988,7 @@ xiaomi_dataobject_dict = {
     0x484E: obj484e,
     0x4851: obj4851,
     0x4852: obj4852,
+    0x487B: obj487b,
     0x4A01: obj4a01,
     0x4A08: obj4a08,
     0x4A0C: obj4a0c,
@@ -1943,6 +1998,7 @@ xiaomi_dataobject_dict = {
     0x4A12: obj4a12,
     0x4A13: obj4a13,
     0x4A1A: obj4a1a,
+    0x4A68: obj4a68,
     0x4C01: obj4c01,
     0x4C02: obj4c02,
     0x4C03: obj4c03,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,9 +2,12 @@
 
 import logging
 import struct
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
+from cryptography.hazmat.primitives.ciphers.aead import AESCCM
 from home_assistant_bluetooth import BluetoothServiceInfo
 from sensor_state_data import (
     BinarySensorDescription,
@@ -27,6 +30,9 @@ from xiaomi_ble.parser import (
     ExtendedSensorDeviceClass,
     XiaomiBluetoothDeviceData,
     obj4a08,
+    obj4a68,
+    obj487b,
+    obj4806,
 )
 
 KEY_BATTERY = DeviceKey(key="battery", device_id=None)
@@ -65,6 +71,8 @@ KEY_LOCK_METHOD = DeviceKey(key="lock_method", device_id=None)
 KEY_MASS_NON_STABILIZED = DeviceKey(key="mass_non_stabilized", device_id=None)
 KEY_MASS = DeviceKey(key="mass", device_id=None)
 KEY_MOISTURE = DeviceKey(key="moisture", device_id=None)
+KEY_BOTTOM_SUBMERSION = DeviceKey(key="bottom_submersion", device_id=None)
+KEY_TOP_SPLASH = DeviceKey(key="top_splash", device_id=None)
 KEY_POWER = DeviceKey(key="power", device_id=None)
 KEY_SCORE = DeviceKey(key="score", device_id=None)
 KEY_SIGNAL_STRENGTH = DeviceKey(key="signal_strength", device_id=None)
@@ -114,6 +122,30 @@ def bytes_to_service_info(
         service_uuids=["0000fe95-0000-1000-8000-00805f9b34fb"],
         source="",
     )
+
+
+def sjws02lm_encrypted_service_info(
+    objects: bytes,
+    *,
+    counter: int,
+) -> BluetoothServiceInfo:
+    """Build a synthetic encrypted SJWS02LM MiBeacon v5 advertisement."""
+    address = "12:34:56:78:9A:BC"
+    mac = bytes.fromhex(address.replace(":", ""))
+    bindkey = bytes.fromhex("00112233445566778899aabbccddeeff")
+    frame_control = 0x5958
+    product_id = 0x6375
+    header = (
+        frame_control.to_bytes(2, "little")
+        + product_id.to_bytes(2, "little")
+        + bytes([counter])
+        + mac[::-1]
+    )
+    extended_counter = bytes([counter, 0, 0])
+    nonce = mac[::-1] + header[2:5] + extended_counter
+    encrypted = AESCCM(bindkey, tag_length=4).encrypt(nonce, objects, b"\x11")
+    payload = header + encrypted[:-4] + extended_counter + encrypted[-4:]
+    return bytes_to_service_info(payload, address=address)
 
 
 def test_blank_advertisements_then_encrypted():
@@ -3728,6 +3760,79 @@ def test_Xiaomi_RS1BB_MI_obj4806():
             ),
         },
     )
+
+
+@pytest.mark.parametrize(
+    ("object_type", "object_value", "entity_key", "expected_state"),
+    [
+        (0x4806, 1, KEY_BOTTOM_SUBMERSION, True),
+        (0x4806, 0, KEY_BOTTOM_SUBMERSION, False),
+        (0x487B, 1, KEY_TOP_SPLASH, True),
+        (0x487B, 0, KEY_TOP_SPLASH, False),
+        (0x4A68, 0, KEY_BOTTOM_SUBMERSION, True),
+        (0x4A68, 1, KEY_BOTTOM_SUBMERSION, False),
+        (0x4A68, 2, KEY_TOP_SPLASH, True),
+        (0x4A68, 3, KEY_TOP_SPLASH, False),
+    ],
+)
+def test_Xiaomi_SJWS02LM_water_state(
+    object_type: int,
+    object_value: int,
+    entity_key: DeviceKey,
+    expected_state: bool,
+) -> None:
+    """Test both persistent states and transition events from SJWS02LM."""
+    objects = object_type.to_bytes(2, "little") + bytes([1, object_value])
+    advertisement = sjws02lm_encrypted_service_info(objects, counter=object_value + 1)
+    bindkey = bytes.fromhex("00112233445566778899aabbccddeeff")
+
+    device = XiaomiBluetoothDeviceData(bindkey=bindkey)
+    assert device.supported(advertisement)
+    assert device.bindkey_verified
+    update = device.update(advertisement)
+
+    assert device.sleepy_device
+    assert update.devices[None].model == "SJWS02LM"
+    assert (
+        update.binary_entity_descriptions[entity_key].device_class
+        == BinarySensorDeviceClass.MOISTURE
+    )
+    assert update.binary_entity_values[entity_key].native_value is expected_state
+
+
+def test_Xiaomi_SJWS02LM_battery_percentage() -> None:
+    """Test that object 0x4C03 is the direct battery percentage."""
+    objects = (0x4C03).to_bytes(2, "little") + bytes([1, 50])
+    advertisement = sjws02lm_encrypted_service_info(objects, counter=9)
+    bindkey = bytes.fromhex("00112233445566778899aabbccddeeff")
+
+    device = XiaomiBluetoothDeviceData(bindkey=bindkey)
+    assert device.supported(advertisement)
+    update = device.update(advertisement)
+
+    assert update.entity_values[KEY_BATTERY].native_value == 50
+
+
+@pytest.mark.parametrize(
+    ("parser", "payload", "device_type"),
+    [
+        (obj4806, b"", "SJWS02LM"),
+        (obj487b, b"", "SJWS02LM"),
+        (obj487b, b"\x01", "OTHER_MODEL"),
+        (obj4a68, b"", "SJWS02LM"),
+        (obj4a68, b"\x00", "OTHER_MODEL"),
+        (obj4a68, b"\x04", "SJWS02LM"),
+    ],
+)
+def test_Xiaomi_SJWS02LM_ignores_invalid_or_unrelated_objects(
+    parser: Callable[[bytes, XiaomiBluetoothDeviceData, str], dict[str, Any]],
+    payload: bytes,
+    device_type: str,
+) -> None:
+    """Do not create states from malformed data or another Xiaomi model."""
+    device = Mock()
+    assert parser(payload, device, device_type) == {}
+    device.update_predefined_binary_sensor.assert_not_called()
 
 
 def test_Xiaomi_XMWXKG01YL():


### PR DESCRIPTION
## Summary

- register Xiaomi Water Leak Sensor 2 (`SJWS02LM`, MiOT model `xiaomi.flood.oh83w`, product ID `0x6375`) as a sleepy device
- expose the lower submersion state (`0x4806`) and upper splash state (`0x487B`) as separate moisture binary sensors
- use water transition object `0x4A68` to reconcile lower alarm/clear (`0`/`1`) and upper alarm/clear (`2`/`3`) packets
- retain the existing `0x4C03` battery parser, which this device reports as a direct percentage

The object mapping was verified with a physical China-region SJWS02LM by activating and clearing both contact groups and pressing the battery-report button. Real device credentials and ciphertext are intentionally not included. Tests generate deterministic MiBeacon v5 packets with a synthetic MAC and bind key. They also cover malformed objects, unknown events, and ensure the new object codes do not affect unrelated Xiaomi models.

## Tests

- `pytest`: 147 passed
- all repository pre-commit hooks passed, including mypy, flake8, black, isort, codespell and private-key detection