### PR TITLE
feat: add product identification for loock.lock.h01lyk

### DIFF
--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -252,6 +252,10 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         name="Door Lock",
         model="XMZNMS08LM",
     ),
+    0x48C4: DeviceEntry(
+        name="Door Lock",
+        model="loock.lock.h01lyk",
+    ),
     0x07BF: DeviceEntry(
         name="Wireless Switch",
         model="YLAI003",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -241,6 +241,60 @@ def test_blank_advertisements_then_unencrypted_last_service_info():
     assert device.last_service_info == advertisement
 
 
+@pytest.mark.parametrize(
+    ("product_id", "expected_supported"), [(18628, True), (18390, False)]
+)
+def test_e30_product_identification(product_id, expected_supported):
+    """Recognize only the catalogued E30 PID using synthetic identity-only frames."""
+    address = "AA:BB:CC:DD:EE:01"
+    mac = bytes.fromhex(address.replace(":", ""))
+    payload = struct.pack("<HHB", 0x5510, product_id, 0xA7) + mac[::-1]
+    advertisement = bytes_to_service_info(payload, address=address)
+    device = XiaomiBluetoothDeviceData()
+
+    assert device.supported(advertisement) is expected_supported
+    update = device.update(advertisement)
+
+    assert device.pending is True
+    assert device.encryption_scheme == EncryptionScheme.NONE
+    assert not device.bindkey_verified
+    assert not device.sleepy_device
+    assert device.last_service_info is None
+    assert not device.poll_needed(advertisement, None)
+
+    if expected_supported:
+        assert device.device_id == product_id
+        assert device.device_type == "loock.lock.h01lyk"
+        assert update == SensorUpdate(
+            title="Door Lock EE01 (loock.lock.h01lyk)",
+            devices={
+                None: SensorDeviceInfo(
+                    name="Door Lock EE01",
+                    manufacturer="Xiaomi",
+                    model="loock.lock.h01lyk",
+                    sw_version=None,
+                    hw_version=None,
+                )
+            },
+            entity_descriptions={
+                KEY_SIGNAL_STRENGTH: SensorDescription(
+                    device_key=KEY_SIGNAL_STRENGTH,
+                    device_class=DeviceClass.SIGNAL_STRENGTH,
+                    native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+                )
+            },
+            entity_values={
+                KEY_SIGNAL_STRENGTH: SensorValue(
+                    name="Signal Strength",
+                    device_key=KEY_SIGNAL_STRENGTH,
+                    native_value=-60,
+                )
+            },
+        )
+    else:
+        assert update == SensorUpdate(title=None, devices={})
+
+
 def test_encryption_needs_v2():
     """Test that we can detect what kind of encryption key a device needs."""
     data_string = b"X0\xb6\x03\xd2\x8b\x98\xc5A$\xf8\xc3I\x14vu~\x00\x00\x00\x99"


### PR DESCRIPTION
## Summary

Register only product ID **18628 (0x48C4)** as `Door Lock`, using the public catalog model identifier `loock.lock.h01lyk` and the existing default Xiaomi manufacturer. This is **product identification only**, not full E30 support.

The existing MiBeacon parsing, encryption/key validation, pending handling and object dispatch are unchanged. The separately catalogued E30-name variant with PID **18390** is not registered. Only `src/xiaomi_ble/devices.py` and `tests/test_parser.py` change; no version or Home Assistant Core changes are included.

## Identity provenance

The independent [XiaomiGateway3 catalog](https://github.com/AlexxIT/XiaomiGateway3/blob/91a9c477a52417b66f232b9abd475374984fb22f/custom_components/xiaomi_gateway3/core/devices.py#L2431-L2453) maps 18628 to Xiaomi Smart Door Lock E30 / `loock.lock.h01lyk`, with related context in [AlexxIT/XiaomiGateway3#1636](https://github.com/AlexxIT/XiaomiGateway3/issues/1636). This establishes a public product identity, **not the over-the-air object layout**: gateway-side MIoT support is not wireless-protocol validation. No hardware model number from an issue report is assumed.

Previous E30 custom-integration code, historical experiments and private GATT mappings are not evidence for this change and are not included.

## Local validation

The new parameterized regression constructs standard identity-only MiBeacon headers using entirely fictional addresses and counters; it does not copy captured packets or historical fixtures. It confirms PID 18628 is recognized while PID 18390 remains unsupported. For the registered identity-only frame, `pending=True`, `bindkey_verified=False`, `last_service_info=None`, and polling is not requested. The update contains metadata and RSSI only, with no events, health, door/lock position or other sensor values.

Focused existing pytest selection in an isolated Python 3.14.7 environment (pytest 9.1.1): **11 passed**.

```powershell
python -m pytest tests\test_parser.py -k 'e30 or blank_advertisements or unknown_device or encryption_needs or bindkey_verified'
```

A separate isolated consumer check was also reported by the coordinating session: candidate library source with Python 3.14.6 and the installed Home Assistant 2026.9.0 native `XiaomiConfigFlow`, mocking only the wait for a new advertisement and registration duplicate checks. The synthetic PID 18628 identity-only input followed `confirm_slow` -> `create_entry`, with `data={}`, `pending=True`, `bindkey_verified=False`, and RSSI only; PID 18390 aborted with `not_supported`. This was not part of the pytest suite and did not start a Home Assistant service or Bluetooth transport, load production configuration, or create a production entry.

## Limits

These are synthetic/parser and isolated configuration-flow checks, **not hardware or production validation**. E30 event, state and encrypted-payload compatibility have not been verified. No GATT, control, battery, private state/event mappings, fabricated default state or key-verification bypass is added. No deployment is included.