### PR TITLE
feat: add support for Mi Smart Safe Box (loock.safe.v1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,8 @@ repos:
     rev: v2.4.3
     hooks:
       - id: codespell
+        # "loock" is the vendor name of the Mi Smart Safe Box (loock.safe.v1)
+        args: ["--ignore-words-list=loock"]
   - repo: https://github.com/PyCQA/flake8
     rev: 7.3.0
     hooks:

--- a/src/xiaomi_ble/devices.py
+++ b/src/xiaomi_ble/devices.py
@@ -240,6 +240,10 @@ DEVICE_TYPES: dict[int, DeviceEntry] = {
         name="Door Lock",
         model="XMZNMST02YD",
     ),
+    0x09B0: DeviceEntry(
+        name="Safe Box",
+        model="loock.safe.v1",
+    ),
     0x0599: DeviceEntry(
         name="Door Lock",
         model="MJZNMS03LM",

--- a/src/xiaomi_ble/parser.py
+++ b/src/xiaomi_ble/parser.py
@@ -961,6 +961,23 @@ def obj100e(
     return {}
 
 
+def obj100f(
+    xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
+) -> dict[str, Any]:
+    """Door state"""
+    # Not part of the public MiBeacon object definition, so it is gated on the
+    # device type. Observed on the Mi Smart Safe Box (loock.safe.v1), which
+    # broadcasts this one byte door state alongside the regular door events
+    # (obj0007): 0x01 while the door is open, 0x00 once it is closed again.
+    # It is sent far more often than obj0007, which is what makes the state
+    # usable after a restart.
+    if device_type == "loock.safe.v1" and len(xobj) == 1:
+        device.update_predefined_binary_sensor(
+            BinarySensorDeviceClass.DOOR, xobj[0] == 0x01
+        )
+    return {}
+
+
 def obj101b(
     xobj: bytes, device: XiaomiBluetoothDeviceData, device_type: str
 ) -> dict[str, Any]:
@@ -1970,6 +1987,7 @@ xiaomi_dataobject_dict = {
     0x100A: obj100a,
     0x100D: obj100d,
     0x100E: obj100e,
+    0x100F: obj100f,
     0x101B: obj101b,
     0x2000: obj2000,
     0x3003: obj3003,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1970,6 +1970,53 @@ def test_Xiaomi_WX08ZM():
     )
 
 
+def test_Xiaomi_loock_safe_v1():
+    """Test Xiaomi parser for the Mi Smart Safe Box (loock.safe.v1)."""
+    # MiBeacon V5 encrypted, product_id 0x09B0, obj100f = 0x01 (door open).
+    data_string = b"XU\xb0\t:\xcc\xbb\xaa\x9c\xc5p+e\rv\x98\x03\x00\xac\xfa\xda\xb9"
+    advertisement = bytes_to_service_info(data_string, address="70:C5:9C:AA:BB:CC")
+    bindkey = "00112233445566778899aabbccddeeff"
+
+    device = XiaomiBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
+    assert device.supported(advertisement)
+    assert device.bindkey_verified
+    assert device.update(advertisement) == SensorUpdate(
+        title="Safe Box BBCC (loock.safe.v1)",
+        devices={
+            None: SensorDeviceInfo(
+                name="Safe Box BBCC",
+                manufacturer="Xiaomi",
+                model="loock.safe.v1",
+                hw_version=None,
+                sw_version="Xiaomi (MiBeacon V5 encrypted)",
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement="dBm",
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                name="Signal Strength", device_key=KEY_SIGNAL_STRENGTH, native_value=-60
+            ),
+        },
+        binary_entity_descriptions={
+            KEY_BINARY_DOOR: BinarySensorDescription(
+                device_key=KEY_BINARY_DOOR,
+                device_class=BinarySensorDeviceClass.DOOR,
+            ),
+        },
+        binary_entity_values={
+            KEY_BINARY_DOOR: BinarySensorValue(
+                device_key=KEY_BINARY_DOOR, name="Door", native_value=True
+            ),
+        },
+    )
+
+
 def test_Xiaomi_MCCGQ02HL():
     """Test Xiaomi parser for MCCGQ02HL."""
     data_string = b"XX\x8b\t\xa3\xae!\x81\xec\xaa\xe4\x0e,U<\x04\x00\x00\xd2\x8aP\x0c"


### PR DESCRIPTION
## Summary

Adds support for the **Mi Smart Safe Box** (`loock.safe.v1`, product id `0x09B0`).

The device is currently not recognised at all: it advertises encrypted MiBeacon
V5 frames on `0xFE95`, but because `0x09B0` is missing from `DEVICE_TYPES`, the
Home Assistant discovery flow aborts silently and no device is ever offered.

Two changes:

1. **`devices.py`** — add `0x09B0: Safe Box (loock.safe.v1)`.
2. **`parser.py`** — add `obj100f`, the one byte door state this device sends.

## About obj100f

`0x100F` is not in the public MiBeacon object definition and is not handled by
ble_monitor either, so the handler is gated on the device type rather than
applied globally, in the same spirit as the `DSL-C08` branch in `obj100e`.

What the device actually sends (captured from a real unit over ~10 minutes of
opening and closing the door, decrypted with its bindkey):

| object | meaning | already supported |
|---|---|---|
| `0x0007` | door event (open / close) | yes (`obj0007`) |
| `0x000B` | lock event (method, key id, timestamp) | yes (`obj000b`) |
| `0x100A` | battery | yes (`obj100a`) |
| `0x100F` | door state, `0x01` open / `0x00` closed | **this PR** |

`0x100F` was by far the most frequent of the four (5 of 8 event frames), and it
is the only one that reports the *current* state rather than a transition, so
without it the door state stays unknown until the next `0x0007` happens to
arrive. Its value always agreed with the surrounding `0x0007` events.

Idle frames are the usual 11 byte beacon (frame control `0x5510`); the device
only emits a payload (`0x5558` / `0x5548`) when the door is operated.

## Test

Added `test_Xiaomi_loock_safe_v1`. The advertisement in the test was generated
for this test with a dummy bindkey and a fabricated MAC — it is not a capture
from the real device.

`pytest` 148 passed; `black`, `isort` and `flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
